### PR TITLE
Enabling R scripts to run and Installing required R Packages.sql

### DIFF
--- a/samples/features/r-services/Telco Customer Churn/SQL Server/Enabling R scripts to run and Installing required R Packages.sql
+++ b/samples/features/r-services/Telco Customer Churn/SQL Server/Enabling R scripts to run and Installing required R Packages.sql
@@ -1,0 +1,69 @@
+--Enabling sp_execute_external_script to run R scripts in SQL Server 2016 and installing package in order to run the Script TelcoChurn-Main.sql and TelcoChurn-Operationalize.sql sucessfully.
+
+--SP_EXECUTE_EXTERNAL_SCRIPT is a stored procedure that execute provided script as argument on external script to a provided language (in this case R language). To enable normal function of this external stored procedure, you must have administrator access to your SQL Server instance in order to run sp_configure command (and set following configuration):
+
+EXECUTE sp_configure;
+GO
+--To enable execution of external script add an argument:
+
+EXECUTE sp_configure 'external scripts enabled', 1;
+GO
+--And after that run the reconfiguration as:
+
+RECONFIGURE;
+GO
+
+--InstallPackage using sp_execute_external_script
+EXECUTE sp_execute_external_script    
+       @language = N'R'    
+      ,@script=N'install.packages("ggplot")'
+WITH RESULT SETS (( ResultSet VARCHAR(50)));
+
+-- using Download.file command
+EXECUTE sp_execute_external_script    
+       @language = N'R'    
+      ,@script=N'download.file("https://cran.r-project.org/bin/windows/contrib/3.4/ggplot2_2.1.0.zip","ggplot")
+                 install.packages("ggplot", repos = NULL, type = "source")'
+WITH RESULT SETS (( ResultSet VARCHAR(50)));
+
+--InstallPackage using sp_execute_external_script
+EXECUTE sp_execute_external_script    
+       @language = N'R'    
+      ,@script=N'install.packages("gplots")'
+WITH RESULT SETS (( ResultSet VARCHAR(50)));
+
+-- using Download.file command
+EXECUTE sp_execute_external_script    
+       @language = N'R'    
+      ,@script=N'download.file("https://cran.r-project.org/bin/windows/contrib/3.4/gplots_3.0.1.zip","gplots")
+                 install.packages("gplots", repos = NULL, type = "source")'
+WITH RESULT SETS (( ResultSet VARCHAR(50)));
+
+
+
+--InstallPackage using sp_execute_external_script
+EXECUTE sp_execute_external_script    
+       @language = N'R'    
+      ,@script=N'install.packages("xgboost")'
+WITH RESULT SETS (( ResultSet VARCHAR(50)));
+
+-- using Download.file command
+EXECUTE sp_execute_external_script    
+       @language = N'R'    
+      ,@script=N'download.file("https://cran.r-project.org/bin/windows/contrib/3.4/xgboost_0.4-4.zip","xgboost")
+                 install.packages("xgboost", repos = NULL, type = "source")'
+WITH RESULT SETS (( ResultSet VARCHAR(50)));
+
+
+--InstallPackage using sp_execute_external_script
+EXECUTE sp_execute_external_script    
+       @language = N'R'    
+      ,@script=N'install.packages("qcc")'
+WITH RESULT SETS (( ResultSet VARCHAR(50)));
+
+-- using Download.file command
+EXECUTE sp_execute_external_script    
+       @language = N'R'    
+      ,@script=N'download.file("https://cran.r-project.org/bin/windows/contrib/3.4/qcc_2.6.zip","qcc")
+                 install.packages("qcc", repos = NULL, type = "source")'
+WITH RESULT SETS (( ResultSet VARCHAR(50)));


### PR DESCRIPTION
Hi,

I have also uploaded one SQL File which installed required R packages before running the scripts of telco customer churn into my fork repository for sql-server-samples. The file contains Enabling sp_execute_external_script to run R scripts in SQL Server 2016 and installing required R packages in order to run the Script TelcoChurn-Main.sql and TelcoChurn-Operationalize.sql sucessfully. since we need to install those R packages before we run the scripts in order to avoid the error . 
https://github.com/maharjananil/sql-server-samples/blob/master/samples/features/r-services/Telco%20Customer%20Churn/SQL%20Server/Enabling%20R%20scripts%20to%20run%20and%20Installing%20required%20R%20Packages.sql

#102 
so, I think it will be helpful to upload the new SQL file in official repository too.

Thanks,
Anil Maharjan