### PR TITLE
Change of In-Memory Demo

### DIFF
--- a/samples/features/in-memory/t-sql-scripts/enable-in-memory-oltp.sql
+++ b/samples/features/in-memory/t-sql-scripts/enable-in-memory-oltp.sql
@@ -10,7 +10,7 @@
 --    need to use the WITH (SNAPSHOT) hint for ad hoc queries accessing memory-optimized
 --    tables.
 --
--- Applies To: SQL Server 2014 (or higher); Azure SQL Database
+-- Applies To: SQL Server 2016 (or higher); Azure SQL Database
 -- Author: Jos de Bruijn (Microsoft)
 -- Last Updated: 2016-05-02
 

--- a/samples/features/in-memory/ticket-reservations/README.md
+++ b/samples/features/in-memory/ticket-reservations/README.md
@@ -41,8 +41,8 @@ This Windows Forms sample application built on .NET Framework 4.6  demonstrates 
 8. Start the workload with the **Start** button, and run for a while to show perf profile. Then press stop to stop the workload. You can tweak aspects of the workload (e.g., rows per transaction) through the configuration form accessed using the "Options" menue.
 
 9. In the database project,
-	- Change TicketReservations.sql to a memory-optimized table (instructions commented in the file itself)
-	- Change InsertTicketReservations.sql to natively compiled (instructions in the same file)
+	- Change TicketReservationDetail.sql to a memory-optimized table (instructions commented in the file itself)
+	- Change InsertReservationDetails.sql to natively compiled (instructions in the same file)
 
 10. Publish the database project to the same database – the tool will take care of making the necessary changes.
 		Note that, as part of publication, the data is copied from the old disk-based table to the new memory-optimized table, so the longer you run the initial workload, the longer this publication takes. To speed up the process you can run `TRUNCATE TABLE dbo.TicketReservationDetail` in the database.

--- a/samples/features/in-memory/ticket-reservations/TicketReservations/dbo/Stored Procedures/Demo_Reset.sql
+++ b/samples/features/in-memory/ticket-reservations/TicketReservations/dbo/Stored Procedures/Demo_Reset.sql
@@ -1,4 +1,11 @@
 ﻿
 create proc Demo_Reset
 as
-TRUNCATE TABLE dbo.TicketReservationDetail;
+DECLARE @isMemoryTable BIT
+
+SELECT @isMemoryTable = is_memory_optimized FROM sys.tables
+WHERE [name] = 'TicketReservationDetail'
+
+IF(@isMemoryTable= 1) DELETE dbo.TicketReservationDetail
+ELSE TRUNCATE TABLE dbo.TicketReservationDetail;
+


### PR DESCRIPTION
1. t-sql-scripts\enable-in-memory-oltp.sql is appled to sql 2016 or
higher
2. modify the sql script name in readme of ticket-reservations
3. add the table type control for Demo_Reset stored proc.