### PR TITLE
prevent attach failure when db name contains '.'

### DIFF
--- a/samples/manage/windows-containers/mssql-server-2016-express-sp1-windows/start.ps1
+++ b/samples/manage/windows-containers/mssql-server-2016-express-sp1-windows/start.ps1
@@ -46,7 +46,7 @@ if ($null -ne $dbs -And $dbs.Length -gt 0){
 		}
 		
 		$files = $files -join ","
-		$sqlcmd = "sp_detach_db $($db.dbName);CREATE DATABASE $($db.dbName) ON $($files) FOR ATTACH ;"
+		$sqlcmd = "sp_detach_db ""$($db.dbName)"";CREATE DATABASE ""$($db.dbName)"" ON $($files) FOR ATTACH ;"
 
 		Write-Verbose "Invoke-Sqlcmd -Query $($sqlcmd) -ServerInstance '.\SQLEXPRESS'"
 		Invoke-Sqlcmd -Query $sqlcmd -ServerInstance ".\SQLEXPRESS"


### PR DESCRIPTION
When a database name along the lines of "WidgetCatalog_v8.3.433" is passed into the script, attach fails at the "v8.3". Rather than deal with trying to properly escape/encode a `[` and `]` around the names, I found that escaping them with quotes behaves as expected.