### PR TITLE
Link markdown

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -1,25 +1,25 @@
 # Sample Categories
 
-__[applications] (applications/)__
+__[applications](applications/)__
 
 End-to-end sample applications that illustrate the use of SQL Server for specific application scenarios.
 
-__[databases] (databases/)__
+__[databases](databases/)__
 
 Sample databases for SQL Server, Azure SQL Database, and Azure SQL Data Warehouse.
 
-__[demos] (demos/)__
+__[demos](demos/)__
 
 Demos of various SQL features and capabilities that were presented at conferences, in Webcasts, etc...
 
-__[features] (features/)__
+__[features](features/)__
 
 Samples illustrating specific SQL Server and Azure SQL Database features, including In-Memory OLTP, Master Data Services (MDS), and R Services.
 
-__[management] (manage/)__
+__[management](manage/)__
 
 Samples that help with the management of SQL Server and Azure SQL Database.
 
-__[tutorials] (tutorials/)__
+__[tutorials](tutorials/)__
 
 Samples showing how to connect to SQL databases using various programming languages, including Python, C#, Java, Ruby, Node.js, and PHP.


### PR DESCRIPTION
Links appeared as: "[tutorials] (tutorials/)", changed to link markdown for functional hyperlinks.