### PR TITLE
Fix URLs

### DIFF
--- a/samples/tutorials/c#/RHEL/README.md
+++ b/samples/tutorials/c#/RHEL/README.md
@@ -62,7 +62,7 @@ To run this sample, you need the following prerequisites.
 
 ## Sample details
 
-Please visit the [C# on RHEL tutorial](https://www.microsoft.com/en-us/sql-server/developer-get-started/csharp-rhel) to run through the sample in full with more detail.
+Please visit the [C# on RHEL tutorial](https://www.microsoft.com/en-us/sql-server/developer-get-started/csharp/rhel/) to run through the sample in full with more detail.
 
 <a name=disclaimers></a>
 

--- a/samples/tutorials/c#/Ubuntu/README.md
+++ b/samples/tutorials/c#/Ubuntu/README.md
@@ -62,7 +62,7 @@ To run this sample, you need the following prerequisites.
 
 ## Sample details
 
-Please visit the [C# on Ubuntu tutorial](https://www.microsoft.com/en-us/sql-server/developer-get-started/csharp-ubuntu) to run through the sample in full with more detail.
+Please visit the [C# on Ubuntu tutorial](https://www.microsoft.com/en-us/sql-server/developer-get-started/csharp/ubuntu/) to run through the sample in full with more detail.
 
 <a name=disclaimers></a>
 

--- a/samples/tutorials/c#/Windows/README.md
+++ b/samples/tutorials/c#/Windows/README.md
@@ -50,7 +50,7 @@ To run this sample, you need the following prerequisites.
 
 ## Sample details
 
-Please visit the [C# on Windows tutorial](https://www.microsoft.com/en-us/sql-server/developer-get-started/csharp-windows) to run through the sample in full with more detail.
+Please visit the [C# on Windows tutorial](https://www.microsoft.com/en-us/sql-server/developer-get-started/csharp/win/) to run through the sample in full with more detail.
 
 <a name=disclaimers></a>
 

--- a/samples/tutorials/c#/macOS/README.md
+++ b/samples/tutorials/c#/macOS/README.md
@@ -62,7 +62,7 @@ To run this sample, you need the following prerequisites.
 
 ## Sample details
 
-Please visit the [C# on macOS tutorial](https://www.microsoft.com/en-us/sql-server/developer-get-started/csharp-mac) to run through the sample in full with more detail.
+Please visit the [C# on macOS tutorial](https://www.microsoft.com/en-us/sql-server/developer-get-started/csharp/macos/) to run through the sample in full with more detail.
 
 <a name=disclaimers></a>
 


### PR DESCRIPTION
Following message appears when trying to contact the URLs: The resource you are looking for has been removed, had its name changed, or is temporarily unavailable.