### PR TITLE
Fix Sparse Checkout README command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Each sample should be in its own folder with a README.md file that follows the [
 ## Cloning only a subset of the repo (with sparse checkout)
 You can follow the steps below to clone individual files from the sql-server-samples git repo. Note: The following script clones only the files under the **features** and **demos** folders. 
 ```
-git clone -n https://github.com/Microsoft/sql-server-samples.\sql-server-samples
+git clone -n https://github.com/Microsoft/sql-server-samples
 cd sql-server-samples
 git config core.sparsecheckout true
 echo samples/features/*| out-file -append -encoding ascii.git/info/sparse-checkout


### PR DESCRIPTION
Fixed git clone --no-checkout command in README

