### PR TITLE
Add failover manifest

### DIFF
--- a/samples/features/high availability/Kubernetes/sample-manifest-files/failover.yaml
+++ b/samples/features/high availability/Kubernetes/sample-manifest-files/failover.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata: {name: manual-failover, namespace: ag1}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata: {name: manual-failover, namespace: ag1}
+rules:
+- apiGroups: ['']
+  resourceNames: [ag1]
+  resources: [configmaps]
+  verbs: [get, update]
+- apiGroups: ['']
+  resourceNames: [ag1]
+  resources: [endpoints]
+  verbs: [get]
+- apiGroups: ['']
+  resources: [pods]
+  verbs: [list]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: {name: manual-failover, namespace: ag1}
+roleRef: {apiGroup: rbac.authorization.k8s.io, kind: Role, name: manual-failover}
+subjects:
+- {kind: ServiceAccount, name: manual-failover}
+---
+apiVersion: batch/v1
+kind: Job
+metadata: {name: manual-failover, namespace: ag1}
+spec:
+  template:
+    metadata: {name: manual-failover}
+    spec:
+      containers:
+      - command: [/mssql-server-k8s-failover]
+        env:
+        - {name: MSSQL_K8S_AG_NAME, value: ag1}
+        - {name: MSSQL_K8S_NEW_PRIMARY, value: <containerName>}
+        - name: MSSQL_K8S_NAMESPACE
+          valueFrom:
+            fieldRef: {fieldPath: metadata.namespace}
+        image: mcr.microsoft.com/mssql/ha:vNext-CTP2.0-ubuntu
+        name: manual-failover
+      restartPolicy: Never
+      serviceAccount: manual-failover


### PR DESCRIPTION
To failover a SQL Server AG primary replica, update this manifest with the <containerName> of your SQL Server instance. Apply to the cluster. After the job completes, delete the job.