### PR TITLE
Updating StockItem history

### DIFF
--- a/samples/databases/wide-world-importers/wwi-ssdt/wwi-ssdt/PostDeploymentScripts/Script.PostDeployment1.sql
+++ b/samples/databases/wide-world-importers/wwi-ssdt/wwi-ssdt/PostDeploymentScripts/Script.PostDeployment1.sql
@@ -172,6 +172,7 @@ EXEC DataLoadSimulation.DailyProcessToCreateHistory
 GO
 
 :r .\pds400-ins-unkown-orderline.sql
+:r .\pds410-update-archive-tables.sql
 
 /*
   There is one other stored procedure you may find useful:

--- a/samples/databases/wide-world-importers/wwi-ssdt/wwi-ssdt/PostDeploymentScripts/pds410-update-archive-tables.sql
+++ b/samples/databases/wide-world-importers/wwi-ssdt/wwi-ssdt/PostDeploymentScripts/pds410-update-archive-tables.sql
@@ -1,0 +1,21 @@
+﻿-- NOTE: This script should be moved to MakeTemporalChanges procedure, but currently it doesn't work there.
+-- jovanpop creating a separate file here.
+-- @TODO: Investigate how to move it there.
+
+PRINT N'Updating StockItems history...'
+GO
+EXEC DataloadSimulation.DeactivatetemporalTablesBeforeDataLoad;
+GO
+UPDATE Warehouse.StockItems_Archive
+SET UnitPrice = s.UnitPrice * (1 - .05 *(DATEDIFF(DAY, sa.ValidFrom, GETDATE())/365 )),
+        RecommendedRetailPrice = s.RecommendedRetailPrice * (1 - .03 *(DATEDIFF(DAY, sa.ValidFrom, GETDATE())/365 )),
+        TaxRate = s.TaxRate * (1 + .02 *(DATEDIFF(DAY, sa.ValidFrom, GETDATE())/365 )),
+        QuantityPerOuter = CEILING(s.QuantityPerOuter * (1 + .05 *(DATEDIFF(DAY, sa.ValidFrom, GETDATE())/365 ))),
+        LeadTimeDays = CEILING(s.LeadTimeDays * (1 + .03 *(DATEDIFF(DAY, sa.ValidFrom, GETDATE())/365 ))),
+        TypicalWeightPerUnit = CEILING(s.TypicalWeightPerUnit * (1 + .02 *(DATEDIFF(DAY, sa.ValidFrom, GETDATE())/365 )))
+    FROM Warehouse.StockItems_Archive sa
+		JOIN Warehouse.StockItems s
+			ON sa.StockItemID = s.StockItemID;
+GO
+EXEC DataloadSimulation.ReActivatetemporalTablesAfterDataLoad;
+GO

--- a/samples/databases/wide-world-importers/wwi-ssdt/wwi-ssdt/WideWorldImporters.sqlproj
+++ b/samples/databases/wide-world-importers/wwi-ssdt/wwi-ssdt/WideWorldImporters.sqlproj
@@ -844,5 +844,6 @@
     <None Include="PostDeploymentScripts\pds105-ins-dls-ficticiousnamepool.sql" />
     <None Include="PostDeploymentScripts\pds106-ins-dls-areacode.sql" />
     <None Include="PostDeploymentScripts\pds400-ins-unkown-orderline.sql" />
+    <None Include="PostDeploymentScripts\pds410-update-archive-tables.sql" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Added post-deployment script that updates StockItem history table with lineary increasing prices and lineary decreasing taxes and lead times.