### PR TITLE
Bug in VerifyNSG() function result initialisation

### DIFF
--- a/samples/manage/azure-sql-db-managed-instance/prepare-subnet/prepareSubnet.ps1
+++ b/samples/manage/azure-sql-db-managed-instance/prepare-subnet/prepareSubnet.ps1
@@ -485,7 +485,7 @@ function VerifyNSG {
         $result = @{ 
             nsgSecurityRules = New-Object "$NScollections.List``1[$NSnetworkModels.PSSecurityRule]"
             failedSecurityRules = New-Object "$NScollections.List``1[$NSnetworkModels.PSSecurityRule]"
-            success = $true 
+            success = $false 
         }
         Write-Host("Verifying Network security group for subnet '{0}'."-f $subnet.Name)
         $nsg = LoadNetworkSecurityGroup $subnet


### PR DESCRIPTION
VerifyNSG() has a simple bug - on entering the function the result success flag is incorrectly initialised to $true (optimistic) - when it should be initialised to $false (pessimistic) ... The function can ONLY be successful on one path; IF an NSG is found WITH valid rules. As it was, if NO NSG is found the function will STILL return success and therefore the following script / code used for mitigation will not be executed.