### PR TITLE
Updated URL for the kubernetes dashboard in the setup-k8s-master.sh script

### DIFF
--- a/samples/features/sql-big-data-cluster/deployment/kubeadm/ubuntu/setup-k8s-master.sh
+++ b/samples/features/sql-big-data-cluster/deployment/kubeadm/ubuntu/setup-k8s-master.sh
@@ -10,5 +10,5 @@ sudo chown $(id -u):$(id -g) $HOME/.kube/config
 kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
 helm init
 kubectl apply -f rbac.yaml
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/master/src/deploy/recommended/kubernetes-dashboard.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v1.10.1/src/deploy/recommended/kubernetes-dashboard.yaml
 kubectl create clusterrolebinding kubernetes-dashboard --clusterrole=cluster-admin --serviceaccount=kube-system:kubernetes-dashboard


### PR DESCRIPTION
The current url points to a location no longer available so returns a 404 message and the dashboard isn't deploy as part of the script. The update uses the suggested url from the kubernetes github page and corectly points to the dashboard yaml file