### PR TITLE
Updates operator.yaml for CTP 3.0

### DIFF
--- a/samples/features/high availability/Kubernetes/sample-manifest-files/operator.yaml
+++ b/samples/features/high availability/Kubernetes/sample-manifest-files/operator.yaml
@@ -63,6 +63,9 @@ spec:
         - name: MSSQL_K8S_NAMESPACE
           valueFrom:
             fieldRef: {fieldPath: metadata.namespace}
-        image: mcr.microsoft.com/mssql/ha:2019-CTP2.1-ubuntu
+        - name: MSSQL_POD_NAME
+          valueFrom:
+            fieldRef: {fieldPath: metadata.name}
+        image: mcr.microsoft.com/mssql/ha:2019-CTP3.0-ubuntu
         name: mssql-operator
       serviceAccount: mssql-operator


### PR DESCRIPTION
Changed the image for the operator to reflect the CTP 3.0 ubuntu image. Added required environment variable MSSQL_POD_NAME as required by the CTP 3.0 image.