### PR TITLE
Fixed hyperlink typo in Readme.md

### DIFF
--- a/samples/features/sql-clr/Curl/README.md
+++ b/samples/features/sql-clr/Curl/README.md
@@ -9,7 +9,7 @@ One of the most popular tools for calling an API on `http:` endpoints is [curl](
 
 [About this sample](#about-this-sample)<br/>
 [Build the CLR/CURL extension](#build-functions)<br/>
-[Add RegEx functions to your SQL database](#add-functions)<br/>
+[Add CURL functions to your SQL database](#add-functions)<br/>
 [Test the functions](#test)<br/>
 [Disclaimers](#disclaimers)<br/>
 [Appendix](#appendix) - quick install script for your dev environment.<br/>


### PR DESCRIPTION
Changed 'Regex' to 'CURL' in content links