### PR TITLE
reworked equality test to be sh-compatible

### DIFF
--- a/samples/features/sql-big-data-cluster/deployment/kubeadm/ubuntu/setup-k8s-prereqs.sh
+++ b/samples/features/sql-big-data-cluster/deployment/kubeadm/ubuntu/setup-k8s-prereqs.sh
@@ -19,7 +19,7 @@ apt-get install -y kubelet=$KUBE_DPKG_VERSION kubeadm=$KUBE_DPKG_VERSION kubectl
 curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
 
 . /etc/os-release
-if [ "$UBUNTU_CODENAME" == "bionic" ]; then
+if [ "$UBUNTU_CODENAME" = "bionic" ]; then
     modprobe br_netfilter
 fi
 sysctl net.bridge.bridge-nf-call-iptables=1


### PR DESCRIPTION
running this script as sudo ./setup-k8s-prereqs.sh would hit
"./setup-k8s-prereqs.sh: 22: [: bionic: unexpected operator"

explanation : https://stackoverflow.com/a/3411105

since script is "marketed" as sh, use "=" instead of "==" which works both under sh and bash