### PR TITLE
[SSIS][WWI]Cutoff TIme should be UTC date time

### DIFF
--- a/samples/databases/wide-world-importers/wwi-ssis/wwi-ssis/DailyETLMain.dtsx
+++ b/samples/databases/wide-world-importers/wwi-ssis/wwi-ssis/DailyETLMain.dtsx
@@ -69,7 +69,7 @@
       <DTS:Variables />
       <DTS:ObjectData>
         <ExpressionTask
-          Expression="@[User::TargetETLCutoffTime] = DATEADD(&quot;Minute&quot;, -5, GETDATE()  )" />
+          Expression="@[User::TargetETLCutoffTime] = DATEADD(&quot;Minute&quot;, -5, GETUTCDATE()  )" />
       </DTS:ObjectData>
     </DTS:Executable>
     <DTS:Executable
@@ -86,7 +86,7 @@
       <DTS:ObjectData>
         <SQLTask:SqlTaskData
           SQLTask:Connection="{7C3E3ECC-C5AD-4675-9618-FC08465F8BC9}"
-          SQLTask:SqlStatementSource="DECLARE @YearNumber int =  YEAR(SYSDATETIME());&#xA;&#xA;EXEC Integration.PopulateDateDimensionForYear @YearNumber;" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask" />
+          SQLTask:SqlStatementSource="DECLARE @YearNumber int =  YEAR(SYSUTCDATETIME());&#xA;&#xA;EXEC Integration.PopulateDateDimensionForYear @YearNumber;" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask" />
       </DTS:ObjectData>
     </DTS:Executable>
     <DTS:Executable


### PR DESCRIPTION
Hello,

I have found an issue in WWI - SSIS(ETL Daily) sample package.
In the ETL package,  `Cutoff time` is generated based on system timezone.
But it will be compared system_versioned tables `[ValidFrom]`(UTC) and `[ValidTo]`(UTC) in`WideWorldImporters` DB. (like [GetCityUpdates](https://github.com/microsoft/sql-server-samples/blob/master/samples/databases/wide-world-importers/wwi-ssdt/wwi-ssdt/Integration/Stored%20Procedures/GetCityUpdates.sql))

I believe this does not work as desired unless system's timezone is UTC. (Especially, timezone is UTC+X case)

And, modification for `PopulateDateDimensionForYear` is just for **_consistency_** in the ETL process.
(this one is not an issue.)

Regards.