### PR TITLE
Code example modernization

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at http://editorconfig.org
+
+root = true
+
+[*.php]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.bat]
+end_of_line = crlf

--- a/.gitignore
+++ b/.gitignore
@@ -441,3 +441,6 @@ samples/features/sql-management-objects/src/out/CodeCoverage/CodeCoverage.config
 # Certificates
 *.pem
 *.p12
+
+# Composer
+/vendor/

--- a/composer.json
+++ b/composer.json
@@ -9,5 +9,9 @@
         "squizlabs/php_codesniffer": "^3.5"
     },
     "license": "MIT",
-    "minimum-stability": "stable"
+    "minimum-stability": "stable",
+    "scripts": {
+        "cs-check": "phpcs -p --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1",
+        "cs-fix": "phpcbf -p --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "microsoft/sql-server-samples",
+    "description": "Official Microsoft GitHub Repository containing code samples for SQL Server",
+    "type": "project",
+    "require": {
+        "php": ">=7.0.0"
+    },
+    "require-dev": {
+        "squizlabs/php_codesniffer": "^3.5"
+    },
+    "license": "MIT",
+    "minimum-stability": "stable"
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,72 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "49a34ccb792321ec81984328df884636",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.5.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
+                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2020-04-17T01:09:41+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=7.0.0"
+    },
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<ruleset name="MS SQL Server Examples">
+    <description>The coding standard for MS SQL Server PHP Examples.</description>
+
+    <!-- Folders & files to be checked -->
+    <file>samples/tutorials/php</file>
+
+    <!-- File extensions to be checked -->
+    <arg name="extensions" value="php"/>
+
+    <!-- PSR-2 base standard -->
+    <rule ref="PSR2"/>
+
+    <!-- General sniffs -->
+    <rule ref="Generic.Files.LineLength"/>
+    <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
+    <rule ref="Squiz.Commenting.FunctionCommentThrowTag"/>
+    <rule ref="Squiz.Classes.LowercaseClassKeywords"/>
+    <rule ref="Generic.CodeAnalysis.ForLoopShouldBeWhileLoop"/>
+    <rule ref="Generic.CodeAnalysis.ForLoopWithTestFunctionCall"/>
+    <rule ref="Generic.CodeAnalysis.JumbledIncrementer"/>
+    <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>
+    <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
+    <rule ref="Squiz.Commenting.DocCommentAlignment"/>
+    <rule ref="Generic.Formatting.NoSpaceAfterCast"/>
+    <rule ref="Squiz.Operators.ValidLogicalOperators"/>
+    <rule ref="Generic.PHP.DeprecatedFunctions"/>
+    <rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops"/>
+    <rule ref="Squiz.PHP.Eval"/>
+    <rule ref="Generic.PHP.ForbiddenFunctions"/>
+    <rule ref="Squiz.PHP.NonExecutableCode"/>
+    <rule ref="Squiz.Classes.ClassFileName"/>
+    <rule ref="Squiz.Scope.MemberVarScope"/>
+    <rule ref="Squiz.Scope.StaticThisUsage"/>
+    <rule ref="Squiz.WhiteSpace.CastSpacing"/>
+    <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
+    <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing"/>
+    <rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
+    <rule ref="Squiz.WhiteSpace.ScopeClosingBrace"/>
+    <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
+        <properties>
+            <property name="equalsSpacing" value="1"/>
+        </properties>
+    </rule>
+
+</ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -11,6 +11,11 @@
     <!-- PSR-2 base standard -->
     <rule ref="PSR2"/>
 
+    <!-- Disable code style sniff on side effects -->
+    <rule ref="PSR1">
+        <exclude name="PSR1.Files.SideEffects"/>
+    </rule>
+
     <!-- General sniffs -->
     <rule ref="Generic.Files.LineLength"/>
     <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>

--- a/samples/tutorials/php/1.0 PHP Configuration and Getting Started/test.php
+++ b/samples/tutorials/php/1.0 PHP Configuration and Getting Started/test.php
@@ -15,7 +15,7 @@ $tsql = "SELECT [CompanyName] FROM SalesLT.Customer";
 $getProducts = sqlsrv_query($conn, $tsql);
 
 if ($getProducts == false) {
-    die(FormatErrors(sqlsrv_errors()));
+    die(formatErrors(sqlsrv_errors()));
 }
 
 $productCount = 0;
@@ -38,7 +38,7 @@ VALUES ('SQL Server 15', 'SQL Server 12', 0, 0, getdate());";
 
 $insertReview = sqlsrv_query($conn, $tsql);
 if ($insertReview == false) {
-    die(FormatErrors(sqlsrv_errors()));
+    die(formatErrors(sqlsrv_errors()));
 }
 
 while ($row = sqlsrv_fetch_array($insertReview, SQLSRV_FETCH_ASSOC)) {
@@ -51,11 +51,11 @@ $params = ["SQL Server 15"];
 
 $deleteReview = sqlsrv_prepare($conn, $tsql, $params);
 if ($deleteReview == false) {
-    die(FormatErrors(sqlsrv_errors()));
+    die(formatErrors(sqlsrv_errors()));
 }
 
 if (sqlsrv_execute($deleteReview) == false) {
-    die(FormatErrors(sqlsrv_errors()));
+    die(formatErrors(sqlsrv_errors()));
 }
 
 while ($row = sqlsrv_fetch_array($deleteReview, SQLSRV_FETCH_ASSOC)) {

--- a/samples/tutorials/php/1.0 PHP Configuration and Getting Started/test.php
+++ b/samples/tutorials/php/1.0 PHP Configuration and Getting Started/test.php
@@ -1,63 +1,62 @@
 <?php
-    echo "\n";
-    $serverName = "tcp:yourserver.database.windows.net,1433";
+echo "\n";
+$serverName = "tcp:yourserver.database.windows.net,1433";
 
-    $connectionOptions = array("Database"=>"yourpassword",
-        "Uid"=>"yourusername", "PWD"=>"yourpassword");
+$connectionOptions = [
+    "Database" => "yourpassword",
+    "Uid" => "yourusername",
+    "PWD" => "yourpassword",
+];
 
-    $conn = sqlsrv_connect($serverName, $connectionOptions);
+$conn = sqlsrv_connect($serverName, $connectionOptions);
 
-    $tsql = "SELECT [CompanyName] FROM SalesLT.Customer";
+$tsql = "SELECT [CompanyName] FROM SalesLT.Customer";
 
-        $getProducts = sqlsrv_query($conn, $tsql);
+$getProducts = sqlsrv_query($conn, $tsql);
 
-        if ($getProducts == FALSE)
-            die(FormatErrors(sqlsrv_errors()));
+if ($getProducts == false) {
+    die(FormatErrors(sqlsrv_errors()));
+}
 
-        $productCount = 0;
-        $ctr = 0;
-        while($row = sqlsrv_fetch_array($getProducts, SQLSRV_FETCH_ASSOC))
-        {   
-            $ctr++;
-            echo($row['CompanyName']);
-            echo("<br/>");
-            $productCount++;
-            if($ctr>10)
-                break;
-        }
+$productCount = 0;
+$ctr = 0;
+while ($row = sqlsrv_fetch_array($getProducts, SQLSRV_FETCH_ASSOC)) {
+    $ctr++;
+    echo($row['CompanyName']);
+    echo("<br/>");
+    $productCount++;
+    if ($ctr > 10) {
+        break;
+    }
+}
 
-        sqlsrv_free_stmt($getProducts);
+sqlsrv_free_stmt($getProducts);
 
-         $tsql = "INSERT SalesLT.Product (Name, ProductNumber, StandardCost, ListPrice, SellStartDate) OUTPUT INSERTED.ProductID VALUES ('SQL Server 15', 'SQL Server 12', 0, 0, getdate())";
+$tsql = "INSERT SalesLT.Product (Name, ProductNumber, StandardCost, ListPrice, SellStartDate) OUTPUT INSERTED.ProductID VALUES ('SQL Server 15', 'SQL Server 12', 0, 0, getdate())";
 
+$insertReview = sqlsrv_query($conn, $tsql);
+if ($insertReview == false) {
+    die(FormatErrors(sqlsrv_errors()));
+}
 
-        $insertReview = sqlsrv_query($conn, $tsql);
-        if($insertReview == FALSE)
-            die(FormatErrors( sqlsrv_errors()));
+while ($row = sqlsrv_fetch_array($insertReview, SQLSRV_FETCH_ASSOC)) {
+    echo($row['ProductID']);
+}
+sqlsrv_free_stmt($insertReview);
 
+$tsql = "DELETE FROM [SalesLT].[Product] WHERE Name=?";
+$params = ["SQL Server 15"];
 
-        while($row = sqlsrv_fetch_array($insertReview, SQLSRV_FETCH_ASSOC))
-        {   
-            echo($row['ProductID']);
-        }
-        sqlsrv_free_stmt($insertReview);
+$deleteReview = sqlsrv_prepare($conn, $tsql, $params);
+if ($deleteReview == false) {
+    die(FormatErrors(sqlsrv_errors()));
+}
 
-        $tsql = "DELETE FROM [SalesLT].[Product] WHERE Name=?";
-        $params = array("SQL Server 15");
+if (sqlsrv_execute($deleteReview) == false) {
+    die(FormatErrors(sqlsrv_errors()));
+}
 
-        $deleteReview = sqlsrv_prepare($conn, $tsql, $params);
-        if($deleteReview == FALSE)
-            die(FormatErrors(sqlsrv_errors()));
-
-        if(sqlsrv_execute($deleteReview) == FALSE)
-            die(FormatErrors(sqlsrv_errors()));
-
-        while($row = sqlsrv_fetch_array($deleteReview, SQLSRV_FETCH_ASSOC))
-        {   
-            echo($row['ProductID']);
-        }
-        sqlsrv_free_stmt($deleteReview);
-       
-
-?>
-
+while ($row = sqlsrv_fetch_array($deleteReview, SQLSRV_FETCH_ASSOC)) {
+    echo($row['ProductID']);
+}
+sqlsrv_free_stmt($deleteReview);

--- a/samples/tutorials/php/1.0 PHP Configuration and Getting Started/test.php
+++ b/samples/tutorials/php/1.0 PHP Configuration and Getting Started/test.php
@@ -14,7 +14,7 @@ $tsql = 'SELECT [CompanyName] FROM SalesLT.Customer';
 
 $getProducts = sqlsrv_query($conn, $tsql);
 
-if ($getProducts == false) {
+if ($getProducts === false) {
     die(formatErrors(sqlsrv_errors()));
 }
 
@@ -37,7 +37,7 @@ OUTPUT INSERTED.ProductID
 VALUES ('SQL Server 15', 'SQL Server 12', 0, 0, getdate());";
 
 $insertReview = sqlsrv_query($conn, $tsql);
-if ($insertReview == false) {
+if ($insertReview === false) {
     die(formatErrors(sqlsrv_errors()));
 }
 
@@ -50,11 +50,11 @@ $tsql = 'DELETE FROM [SalesLT].[Product] WHERE Name=?';
 $params = ['SQL Server 15'];
 
 $deleteReview = sqlsrv_prepare($conn, $tsql, $params);
-if ($deleteReview == false) {
+if ($deleteReview === false) {
     die(formatErrors(sqlsrv_errors()));
 }
 
-if (sqlsrv_execute($deleteReview) == false) {
+if (sqlsrv_execute($deleteReview) === false) {
     die(formatErrors(sqlsrv_errors()));
 }
 

--- a/samples/tutorials/php/1.0 PHP Configuration and Getting Started/test.php
+++ b/samples/tutorials/php/1.0 PHP Configuration and Getting Started/test.php
@@ -15,7 +15,8 @@ $tsql = 'SELECT [CompanyName] FROM SalesLT.Customer';
 $getProducts = sqlsrv_query($conn, $tsql);
 
 if ($getProducts === false) {
-    die(format_errors(sqlsrv_errors()));
+    format_errors(sqlsrv_errors());
+    die();
 }
 
 $productCount = 0;
@@ -38,7 +39,8 @@ VALUES ('SQL Server 15', 'SQL Server 12', 0, 0, getdate());";
 
 $insertReview = sqlsrv_query($conn, $tsql);
 if ($insertReview === false) {
-    die(format_errors(sqlsrv_errors()));
+    format_errors(sqlsrv_errors());
+    die();
 }
 
 while ($row = sqlsrv_fetch_array($insertReview, SQLSRV_FETCH_ASSOC)) {
@@ -51,11 +53,13 @@ $params = ['SQL Server 15'];
 
 $deleteReview = sqlsrv_prepare($conn, $tsql, $params);
 if ($deleteReview === false) {
-    die(format_errors(sqlsrv_errors()));
+    format_errors(sqlsrv_errors());
+    die();
 }
 
 if (sqlsrv_execute($deleteReview) === false) {
-    die(format_errors(sqlsrv_errors()));
+    format_errors(sqlsrv_errors());
+    die();
 }
 
 while ($row = sqlsrv_fetch_array($deleteReview, SQLSRV_FETCH_ASSOC)) {

--- a/samples/tutorials/php/1.0 PHP Configuration and Getting Started/test.php
+++ b/samples/tutorials/php/1.0 PHP Configuration and Getting Started/test.php
@@ -32,7 +32,9 @@ while ($row = sqlsrv_fetch_array($getProducts, SQLSRV_FETCH_ASSOC)) {
 
 sqlsrv_free_stmt($getProducts);
 
-$tsql = "INSERT SalesLT.Product (Name, ProductNumber, StandardCost, ListPrice, SellStartDate) OUTPUT INSERTED.ProductID VALUES ('SQL Server 15', 'SQL Server 12', 0, 0, getdate())";
+$tsql = "INSERT SalesLT.Product (Name, ProductNumber, StandardCost, ListPrice, SellStartDate)
+OUTPUT INSERTED.ProductID
+VALUES ('SQL Server 15', 'SQL Server 12', 0, 0, getdate());";
 
 $insertReview = sqlsrv_query($conn, $tsql);
 if ($insertReview == false) {

--- a/samples/tutorials/php/1.0 PHP Configuration and Getting Started/test.php
+++ b/samples/tutorials/php/1.0 PHP Configuration and Getting Started/test.php
@@ -1,16 +1,16 @@
 <?php
 echo "\n";
-$serverName = "tcp:yourserver.database.windows.net,1433";
+$serverName = 'tcp:yourserver.database.windows.net,1433';
 
 $connectionOptions = [
-    "Database" => "yourpassword",
-    "Uid" => "yourusername",
-    "PWD" => "yourpassword",
+    'Database' => 'yourpassword',
+    'Uid' => 'yourusername',
+    'PWD' => 'yourpassword',
 ];
 
 $conn = sqlsrv_connect($serverName, $connectionOptions);
 
-$tsql = "SELECT [CompanyName] FROM SalesLT.Customer";
+$tsql = 'SELECT [CompanyName] FROM SalesLT.Customer';
 
 $getProducts = sqlsrv_query($conn, $tsql);
 
@@ -23,7 +23,7 @@ $ctr = 0;
 while ($row = sqlsrv_fetch_array($getProducts, SQLSRV_FETCH_ASSOC)) {
     $ctr++;
     echo($row['CompanyName']);
-    echo("<br/>");
+    echo('<br/>');
     $productCount++;
     if ($ctr > 10) {
         break;
@@ -46,8 +46,8 @@ while ($row = sqlsrv_fetch_array($insertReview, SQLSRV_FETCH_ASSOC)) {
 }
 sqlsrv_free_stmt($insertReview);
 
-$tsql = "DELETE FROM [SalesLT].[Product] WHERE Name=?";
-$params = ["SQL Server 15"];
+$tsql = 'DELETE FROM [SalesLT].[Product] WHERE Name=?';
+$params = ['SQL Server 15'];
 
 $deleteReview = sqlsrv_prepare($conn, $tsql, $params);
 if ($deleteReview == false) {

--- a/samples/tutorials/php/1.0 PHP Configuration and Getting Started/test.php
+++ b/samples/tutorials/php/1.0 PHP Configuration and Getting Started/test.php
@@ -15,7 +15,7 @@ $tsql = 'SELECT [CompanyName] FROM SalesLT.Customer';
 $getProducts = sqlsrv_query($conn, $tsql);
 
 if ($getProducts === false) {
-    die(formatErrors(sqlsrv_errors()));
+    die(format_errors(sqlsrv_errors()));
 }
 
 $productCount = 0;
@@ -38,7 +38,7 @@ VALUES ('SQL Server 15', 'SQL Server 12', 0, 0, getdate());";
 
 $insertReview = sqlsrv_query($conn, $tsql);
 if ($insertReview === false) {
-    die(formatErrors(sqlsrv_errors()));
+    die(format_errors(sqlsrv_errors()));
 }
 
 while ($row = sqlsrv_fetch_array($insertReview, SQLSRV_FETCH_ASSOC)) {
@@ -51,11 +51,11 @@ $params = ['SQL Server 15'];
 
 $deleteReview = sqlsrv_prepare($conn, $tsql, $params);
 if ($deleteReview === false) {
-    die(formatErrors(sqlsrv_errors()));
+    die(format_errors(sqlsrv_errors()));
 }
 
 if (sqlsrv_execute($deleteReview) === false) {
-    die(formatErrors(sqlsrv_errors()));
+    die(format_errors(sqlsrv_errors()));
 }
 
 while ($row = sqlsrv_fetch_array($deleteReview, SQLSRV_FETCH_ASSOC)) {

--- a/samples/tutorials/php/1.0 PHP Configuration and Getting Started/test.php
+++ b/samples/tutorials/php/1.0 PHP Configuration and Getting Started/test.php
@@ -1,11 +1,11 @@
 <?php
 echo "\n";
-$serverName = 'tcp:yourserver.database.windows.net,1433';
+$serverName = 'tcp:your_server.database.windows.net,1433';
 
 $connectionOptions = [
-    'Database' => 'yourpassword',
-    'Uid' => 'yourusername',
-    'PWD' => 'yourpassword',
+    'Database' => 'your_database',
+    'Uid' => 'your_username',
+    'PWD' => 'your_password',
 ];
 
 $conn = sqlsrv_connect($serverName, $connectionOptions);

--- a/samples/tutorials/php/2.0 PHP Server programming - Stored procedures, Transactions, and UDFs/test.php
+++ b/samples/tutorials/php/2.0 PHP Server programming - Stored procedures, Transactions, and UDFs/test.php
@@ -145,10 +145,14 @@ while ($row = sqlsrv_fetch_array($getProducts, SQLSRV_FETCH_ASSOC)) {
         break;
     }
     $ctr++;
-    echo $row['SalesOrderID'] . str_repeat('&nbsp;', 13) . $row['CustomerID'] . str_repeat(
-        '&nbsp;',
-        11
-    ) . $row['TotalItems'];
+    echo sprintf(
+        '%s%s%s%s%s',
+        $row['SalesOrderID'],
+        str_repeat('&nbsp;', 13),
+        $row['CustomerID'],
+        str_repeat('&nbsp;', 11),
+        $row['TotalItems']
+    );
     echo('<br/>');
     $productCount++;
 }

--- a/samples/tutorials/php/2.0 PHP Server programming - Stored procedures, Transactions, and UDFs/test.php
+++ b/samples/tutorials/php/2.0 PHP Server programming - Stored procedures, Transactions, and UDFs/test.php
@@ -1,138 +1,132 @@
-<?php	
-	$serverName = "tcp:yourserver.database.windows.net,1433";
-    $connectionOptions = array("Database"=>"yourdatabase",
-        "Uid"=>"yourusername", "PWD"=>"yourpassword");
-    //Establishes the connection
-    $conn = sqlsrv_connect($serverName, $connectionOptions);
-    //////////////////STORED PROCEDURE/////////////////////////    
-    $tsql = "CREATE PROCEDURE sp_GetCompanies22 AS BEGIN SELECT [CompanyName] FROM SalesLT.Customer END";
-    $storedProc = sqlsrv_query($conn, $tsql);
-    if($storedProc == FALSE){
-        echo "Error creating Stored Procedure";
-        die(FormatErrors( sqlsrv_errors()));
-    }    
-    sqlsrv_free_stmt($storedProc);
-
-    $tsql = "exec sp_GETCompanies22";
-    //Executes the query
-    $getProducts = sqlsrv_query($conn, $tsql);
-    //Error handling
-    if ($getProducts == FALSE){
-        echo "Error executing Stored Procedure";    
-        die(FormatErrors(sqlsrv_errors()));
-    }    
-    $productCount = 0;
-    $ctr = 0;
-?>    
-    <h1> First 10 results are after executing the stored procedure:  </h1>
 <?php
-    while($row = sqlsrv_fetch_array($getProducts, SQLSRV_FETCH_ASSOC)){ 
-        //Printing only the first 10 results 
-        if($ctr>9)
-            break; 
-        $ctr++;
-        echo($row['CompanyName']);
-        echo("<br/>");
-        $productCount++;  
-    }
-    sqlsrv_free_stmt($getProducts);
-    $tsql = "DROP PROCEDURE sp_GETCompanies22";
+$serverName = "tcp:yourserver.database.windows.net,1433";
+$connectionOptions = [
+    "Database" => "yourdatabase",
+    "Uid" => "yourusername",
+    "PWD" => "yourpassword",
+];
+//Establishes the connection
+$conn = sqlsrv_connect($serverName, $connectionOptions);
+//////////////////STORED PROCEDURE/////////////////////////
+$tsql = "CREATE PROCEDURE sp_GetCompanies22 AS BEGIN SELECT [CompanyName] FROM SalesLT.Customer END";
+$storedProc = sqlsrv_query($conn, $tsql);
+if ($storedProc == false) {
+    echo "Error creating Stored Procedure";
+    die(FormatErrors(sqlsrv_errors()));
+}
+sqlsrv_free_stmt($storedProc);
 
-    $storedProc = sqlsrv_query($conn, $tsql);
-    if($storedProc == FALSE)
-    {
-        echo "Error dropping Stored Procedure";
-        die(FormatErrors( sqlsrv_errors()));
-    }    
-    sqlsrv_free_stmt($storedProc);
+$tsql = "exec sp_GETCompanies22";
+//Executes the query
+$getProducts = sqlsrv_query($conn, $tsql);
+//Error handling
+if ($getProducts == false) {
+    echo "Error executing Stored Procedure";
+    die(FormatErrors(sqlsrv_errors()));
+}
+$productCount = 0;
+$ctr = 0;
+?>
+    <h1> First 10 results are after executing the stored procedure: </h1>
+<?php
+while ($row = sqlsrv_fetch_array($getProducts, SQLSRV_FETCH_ASSOC)) {
+    //Printing only the first 10 results
+    if ($ctr > 9) {
+        break;
+    }
+    $ctr++;
+    echo($row['CompanyName']);
+    echo("<br/>");
+    $productCount++;
+}
+sqlsrv_free_stmt($getProducts);
+$tsql = "DROP PROCEDURE sp_GETCompanies22";
+
+$storedProc = sqlsrv_query($conn, $tsql);
+if ($storedProc == false) {
+    echo "Error dropping Stored Procedure";
+    die(FormatErrors(sqlsrv_errors()));
+}
+sqlsrv_free_stmt($storedProc);
 ?>
 <?php
-    //////////////////TRANSACTION/////////////////////////
-    if (sqlsrv_begin_transaction($conn) == FALSE)
-    {
-        echo "Error opening connection";    
-        die(FormatErrors(sqlsrv_errors()));
-    }   
+//////////////////TRANSACTION/////////////////////////
+if (sqlsrv_begin_transaction($conn) == false) {
+    echo "Error opening connection";
+    die(FormatErrors(sqlsrv_errors()));
+}
 
-        /* Set up and execute the first query. */
-    $tsql1 = "INSERT INTO SalesLT.SalesOrderDetail
+/* Set up and execute the first query. */
+$tsql1 = "INSERT INTO SalesLT.SalesOrderDetail
        (SalesOrderID,OrderQty,ProductID,UnitPrice)
        VALUES (71774, 22, 709, 33)";
-    $stmt1 = sqlsrv_query($conn, $tsql1);
+$stmt1 = sqlsrv_query($conn, $tsql1);
 
-    /* Set up and execute the second query. */
-    $tsql2 = "UPDATE SalesLT.SalesOrderDetail SET OrderQty = (OrderQty + 1) WHERE ProductID = 709";
-    $stmt2 = sqlsrv_query( $conn, $tsql2);
+/* Set up and execute the second query. */
+$tsql2 = "UPDATE SalesLT.SalesOrderDetail SET OrderQty = (OrderQty + 1) WHERE ProductID = 709";
+$stmt2 = sqlsrv_query($conn, $tsql2);
 
-    /* If both queries were successful, commit the transaction. */
-    /* Otherwise, rollback the transaction. */
-    if($stmt1 && $stmt2)
-    {
-            sqlsrv_commit($conn);
- ?>
-        <h1> Transaction was commited </h1>
+/* If both queries were successful, commit the transaction. */
+/* Otherwise, rollback the transaction. */
+if ($stmt1 && $stmt2) {
+    sqlsrv_commit($conn);
+    ?>
+    <h1> Transaction was commited </h1>
 
-<?php           
-            
-    }
-    else
-    {
-            sqlsrv_rollback($conn);
-            echo "Transaction was rolled back.\n";
-    }
+    <?php
 
-    /* Free statement and connection resources. */
-    sqlsrv_free_stmt( $stmt1);
-    sqlsrv_free_stmt( $stmt2);
+} else {
+    sqlsrv_rollback($conn);
+    echo "Transaction was rolled back.\n";
+}
+
+/* Free statement and connection resources. */
+sqlsrv_free_stmt($stmt1);
+sqlsrv_free_stmt($stmt2);
 
 ?>
 <?php
-    //////////////////UDF/////////////////////////
-    //Dropping function if it already exists
-    $tsql1 = "IF OBJECT_ID(N'dbo.ifGetTotalItems', N'IF') IS NOT NULL DROP FUNCTION dbo.ifGetTotalItems;";
-    $getProducts = sqlsrv_query($conn, $tsql1);
-    //Error handling
-    if ($getProducts == FALSE)
-    {
-        echo "Error deleting the UDF";    
-        die(FormatErrors(sqlsrv_errors()));
-    }
-    $tsql1 = "CREATE FUNCTION dbo.ifGetTotalItems (@OrderID INT) RETURNS TABLE WITH SCHEMABINDING AS RETURN (SELECT SUM(OrderQty) AS TotalItems FROM SalesLT.SalesOrderDetail WHERE SalesOrderID = @OrderID GROUP BY SalesOrderID);";
-    $getProducts = sqlsrv_query($conn, $tsql1);
-    //Error handling
-    if ($getProducts == FALSE)
-    {
-        echo "Error creating the UDF";    
-        die(FormatErrors(sqlsrv_errors()));
-    }
-    $tsql1 = "SELECT s.SalesOrderID, s.OrderDate, s.CustomerID, f.TotalItems FROM SalesLT.SalesOrderHeader s CROSS APPLY dbo.ifGetTotalItems(s.SalesOrderID) f ORDER BY SalesOrderID;";
-    $getProducts = sqlsrv_query($conn, $tsql1);
-    //Error handling
-    if ($getProducts == FALSE)
-    {
-        echo "Error executing the UDF";    
-        die(FormatErrors(sqlsrv_errors()));
-    }   
-    $productCount = 0;
-    $ctr = 0;
-?>    
-    <h1> First 10 results are after executing a query that uses the UDF:  </h1>
-<?php
-    echo "SalesOrderID      CustomerID      TotalItems";
-            echo("<br/>");
-
-    while($row = sqlsrv_fetch_array($getProducts, SQLSRV_FETCH_ASSOC))
-    {  
-        //Printing only the top 10 results
-        if($ctr>9)
-            break; 
-        $ctr++;
-        echo $row['SalesOrderID'] . str_repeat('&nbsp;', 13) . $row['CustomerID'] . str_repeat('&nbsp;', 11) . $row['TotalItems'];
-        echo("<br/>");
-        $productCount++;
-      
-    }
-    sqlsrv_free_stmt($getProducts);
-
-
+//////////////////UDF/////////////////////////
+//Dropping function if it already exists
+$tsql1 = "IF OBJECT_ID(N'dbo.ifGetTotalItems', N'IF') IS NOT NULL DROP FUNCTION dbo.ifGetTotalItems;";
+$getProducts = sqlsrv_query($conn, $tsql1);
+//Error handling
+if ($getProducts == false) {
+    echo "Error deleting the UDF";
+    die(FormatErrors(sqlsrv_errors()));
+}
+$tsql1 = "CREATE FUNCTION dbo.ifGetTotalItems (@OrderID INT) RETURNS TABLE WITH SCHEMABINDING AS RETURN (SELECT SUM(OrderQty) AS TotalItems FROM SalesLT.SalesOrderDetail WHERE SalesOrderID = @OrderID GROUP BY SalesOrderID);";
+$getProducts = sqlsrv_query($conn, $tsql1);
+//Error handling
+if ($getProducts == false) {
+    echo "Error creating the UDF";
+    die(FormatErrors(sqlsrv_errors()));
+}
+$tsql1 = "SELECT s.SalesOrderID, s.OrderDate, s.CustomerID, f.TotalItems FROM SalesLT.SalesOrderHeader s CROSS APPLY dbo.ifGetTotalItems(s.SalesOrderID) f ORDER BY SalesOrderID;";
+$getProducts = sqlsrv_query($conn, $tsql1);
+//Error handling
+if ($getProducts == false) {
+    echo "Error executing the UDF";
+    die(FormatErrors(sqlsrv_errors()));
+}
+$productCount = 0;
+$ctr = 0;
 ?>
+    <h1> First 10 results are after executing a query that uses the UDF: </h1>
+<?php
+echo "SalesOrderID      CustomerID      TotalItems";
+echo("<br/>");
+
+while ($row = sqlsrv_fetch_array($getProducts, SQLSRV_FETCH_ASSOC)) {
+    //Printing only the top 10 results
+    if ($ctr > 9) {
+        break;
+    }
+    $ctr++;
+    echo $row['SalesOrderID'] . str_repeat('&nbsp;', 13) . $row['CustomerID'] . str_repeat('&nbsp;',
+            11) . $row['TotalItems'];
+    echo("<br/>");
+    $productCount++;
+
+}
+sqlsrv_free_stmt($getProducts);

--- a/samples/tutorials/php/2.0 PHP Server programming - Stored procedures, Transactions, and UDFs/test.php
+++ b/samples/tutorials/php/2.0 PHP Server programming - Stored procedures, Transactions, and UDFs/test.php
@@ -7,7 +7,11 @@ $connectionOptions = [
 ];
 // Establishes the connection
 $conn = sqlsrv_connect($serverName, $connectionOptions);
-////////////////// STORED PROCEDURE /////////////////////////
+
+/*
+ * Stored Procedure
+ */
+
 $tsql = "CREATE PROCEDURE sp_GetCompanies22 AS BEGIN SELECT [CompanyName] FROM SalesLT.Customer END";
 $storedProc = sqlsrv_query($conn, $tsql);
 if ($storedProc == false) {
@@ -50,7 +54,10 @@ if ($storedProc == false) {
 sqlsrv_free_stmt($storedProc);
 ?>
 <?php
-////////////////// TRANSACTION /////////////////////////
+/*
+ * Transaction
+ */
+
 if (sqlsrv_begin_transaction($conn) == false) {
     echo "Error opening connection";
     die(FormatErrors(sqlsrv_errors()));
@@ -85,7 +92,9 @@ sqlsrv_free_stmt($stmt2);
 
 ?>
 <?php
-////////////////// UDF /////////////////////////
+/*
+ * UDF
+ */
 // Dropping function if it already exists
 $tsql1 = "IF OBJECT_ID(N'dbo.ifGetTotalItems', N'IF') IS NOT NULL DROP FUNCTION dbo.ifGetTotalItems;";
 $getProducts = sqlsrv_query($conn, $tsql1);

--- a/samples/tutorials/php/2.0 PHP Server programming - Stored procedures, Transactions, and UDFs/test.php
+++ b/samples/tutorials/php/2.0 PHP Server programming - Stored procedures, Transactions, and UDFs/test.php
@@ -5,9 +5,9 @@ $connectionOptions = [
     "Uid" => "yourusername",
     "PWD" => "yourpassword",
 ];
-//Establishes the connection
+// Establishes the connection
 $conn = sqlsrv_connect($serverName, $connectionOptions);
-//////////////////STORED PROCEDURE/////////////////////////
+////////////////// STORED PROCEDURE /////////////////////////
 $tsql = "CREATE PROCEDURE sp_GetCompanies22 AS BEGIN SELECT [CompanyName] FROM SalesLT.Customer END";
 $storedProc = sqlsrv_query($conn, $tsql);
 if ($storedProc == false) {
@@ -17,9 +17,9 @@ if ($storedProc == false) {
 sqlsrv_free_stmt($storedProc);
 
 $tsql = "exec sp_GETCompanies22";
-//Executes the query
+// Executes the query
 $getProducts = sqlsrv_query($conn, $tsql);
-//Error handling
+// Error handling
 if ($getProducts == false) {
     echo "Error executing Stored Procedure";
     die(FormatErrors(sqlsrv_errors()));
@@ -30,7 +30,7 @@ $ctr = 0;
     <h1> First 10 results are after executing the stored procedure: </h1>
 <?php
 while ($row = sqlsrv_fetch_array($getProducts, SQLSRV_FETCH_ASSOC)) {
-    //Printing only the first 10 results
+    // Printing only the first 10 results
     if ($ctr > 9) {
         break;
     }
@@ -50,7 +50,7 @@ if ($storedProc == false) {
 sqlsrv_free_stmt($storedProc);
 ?>
 <?php
-//////////////////TRANSACTION/////////////////////////
+////////////////// TRANSACTION /////////////////////////
 if (sqlsrv_begin_transaction($conn) == false) {
     echo "Error opening connection";
     die(FormatErrors(sqlsrv_errors()));
@@ -85,11 +85,11 @@ sqlsrv_free_stmt($stmt2);
 
 ?>
 <?php
-//////////////////UDF/////////////////////////
-//Dropping function if it already exists
+////////////////// UDF /////////////////////////
+// Dropping function if it already exists
 $tsql1 = "IF OBJECT_ID(N'dbo.ifGetTotalItems', N'IF') IS NOT NULL DROP FUNCTION dbo.ifGetTotalItems;";
 $getProducts = sqlsrv_query($conn, $tsql1);
-//Error handling
+// Error handling
 if ($getProducts == false) {
     echo "Error deleting the UDF";
     die(FormatErrors(sqlsrv_errors()));
@@ -100,7 +100,7 @@ $tsql1 = 'CREATE FUNCTION dbo.ifGetTotalItems (@OrderID INT) RETURNS TABLE WITH 
     GROUP BY SalesOrderID
 );';
 $getProducts = sqlsrv_query($conn, $tsql1);
-//Error handling
+// Error handling
 if ($getProducts == false) {
     echo "Error creating the UDF";
     die(FormatErrors(sqlsrv_errors()));
@@ -110,7 +110,7 @@ FROM SalesLT.SalesOrderHeader s
 CROSS APPLY dbo.ifGetTotalItems(s.SalesOrderID) f
 ORDER BY SalesOrderID;";
 $getProducts = sqlsrv_query($conn, $tsql1);
-//Error handling
+// Error handling
 if ($getProducts == false) {
     echo "Error executing the UDF";
     die(FormatErrors(sqlsrv_errors()));
@@ -124,7 +124,7 @@ echo "SalesOrderID      CustomerID      TotalItems";
 echo("<br/>");
 
 while ($row = sqlsrv_fetch_array($getProducts, SQLSRV_FETCH_ASSOC)) {
-    //Printing only the top 10 results
+    // Printing only the top 10 results
     if ($ctr > 9) {
         break;
     }

--- a/samples/tutorials/php/2.0 PHP Server programming - Stored procedures, Transactions, and UDFs/test.php
+++ b/samples/tutorials/php/2.0 PHP Server programming - Stored procedures, Transactions, and UDFs/test.php
@@ -82,7 +82,7 @@ $stmt2 = sqlsrv_query($conn, $tsql2);
 if ($stmt1 && $stmt2) {
     sqlsrv_commit($conn);
     ?>
-    <h1> Transaction was commited </h1>
+    <h1> Transaction was committed </h1>
 
     <?php
 } else {

--- a/samples/tutorials/php/2.0 PHP Server programming - Stored procedures, Transactions, and UDFs/test.php
+++ b/samples/tutorials/php/2.0 PHP Server programming - Stored procedures, Transactions, and UDFs/test.php
@@ -16,7 +16,7 @@ $tsql = "CREATE PROCEDURE sp_GetCompanies22 AS BEGIN SELECT [CompanyName] FROM S
 $storedProc = sqlsrv_query($conn, $tsql);
 if ($storedProc == false) {
     echo "Error creating Stored Procedure";
-    die(FormatErrors(sqlsrv_errors()));
+    die(formatErrors(sqlsrv_errors()));
 }
 sqlsrv_free_stmt($storedProc);
 
@@ -26,7 +26,7 @@ $getProducts = sqlsrv_query($conn, $tsql);
 // Error handling
 if ($getProducts == false) {
     echo "Error executing Stored Procedure";
-    die(FormatErrors(sqlsrv_errors()));
+    die(formatErrors(sqlsrv_errors()));
 }
 $productCount = 0;
 $ctr = 0;
@@ -49,7 +49,7 @@ $tsql = "DROP PROCEDURE sp_GETCompanies22";
 $storedProc = sqlsrv_query($conn, $tsql);
 if ($storedProc == false) {
     echo "Error dropping Stored Procedure";
-    die(FormatErrors(sqlsrv_errors()));
+    die(formatErrors(sqlsrv_errors()));
 }
 sqlsrv_free_stmt($storedProc);
 ?>
@@ -60,7 +60,7 @@ sqlsrv_free_stmt($storedProc);
 
 if (sqlsrv_begin_transaction($conn) == false) {
     echo "Error opening connection";
-    die(FormatErrors(sqlsrv_errors()));
+    die(formatErrors(sqlsrv_errors()));
 }
 
 /* Set up and execute the first query. */
@@ -101,7 +101,7 @@ $getProducts = sqlsrv_query($conn, $tsql1);
 // Error handling
 if ($getProducts == false) {
     echo "Error deleting the UDF";
-    die(FormatErrors(sqlsrv_errors()));
+    die(formatErrors(sqlsrv_errors()));
 }
 $tsql1 = 'CREATE FUNCTION dbo.ifGetTotalItems (@OrderID INT) RETURNS TABLE WITH SCHEMABINDING AS RETURN (
     SELECT SUM(OrderQty) AS TotalItems FROM SalesLT.SalesOrderDetail
@@ -112,7 +112,7 @@ $getProducts = sqlsrv_query($conn, $tsql1);
 // Error handling
 if ($getProducts == false) {
     echo "Error creating the UDF";
-    die(FormatErrors(sqlsrv_errors()));
+    die(formatErrors(sqlsrv_errors()));
 }
 $tsql1 = "SELECT s.SalesOrderID, s.OrderDate, s.CustomerID, f.TotalItems
 FROM SalesLT.SalesOrderHeader s
@@ -122,7 +122,7 @@ $getProducts = sqlsrv_query($conn, $tsql1);
 // Error handling
 if ($getProducts == false) {
     echo "Error executing the UDF";
-    die(FormatErrors(sqlsrv_errors()));
+    die(formatErrors(sqlsrv_errors()));
 }
 $productCount = 0;
 $ctr = 0;

--- a/samples/tutorials/php/2.0 PHP Server programming - Stored procedures, Transactions, and UDFs/test.php
+++ b/samples/tutorials/php/2.0 PHP Server programming - Stored procedures, Transactions, and UDFs/test.php
@@ -74,7 +74,6 @@ if ($stmt1 && $stmt2) {
     <h1> Transaction was commited </h1>
 
     <?php
-
 } else {
     sqlsrv_rollback($conn);
     echo "Transaction was rolled back.\n";
@@ -123,10 +122,11 @@ while ($row = sqlsrv_fetch_array($getProducts, SQLSRV_FETCH_ASSOC)) {
         break;
     }
     $ctr++;
-    echo $row['SalesOrderID'] . str_repeat('&nbsp;', 13) . $row['CustomerID'] . str_repeat('&nbsp;',
-            11) . $row['TotalItems'];
+    echo $row['SalesOrderID'] . str_repeat('&nbsp;', 13) . $row['CustomerID'] . str_repeat(
+        '&nbsp;',
+        11
+    ) . $row['TotalItems'];
     echo("<br/>");
     $productCount++;
-
 }
 sqlsrv_free_stmt($getProducts);

--- a/samples/tutorials/php/2.0 PHP Server programming - Stored procedures, Transactions, and UDFs/test.php
+++ b/samples/tutorials/php/2.0 PHP Server programming - Stored procedures, Transactions, and UDFs/test.php
@@ -1,9 +1,9 @@
 <?php
-$serverName = 'tcp:yourserver.database.windows.net,1433';
+$serverName = 'tcp:your_server.database.windows.net,1433';
 $connectionOptions = [
-    'Database' => 'yourdatabase',
-    'Uid' => 'yourusername',
-    'PWD' => 'yourpassword',
+    'Database' => 'your_database',
+    'Uid' => 'your_username',
+    'PWD' => ' your_password',
 ];
 // Establishes the connection
 $conn = sqlsrv_connect($serverName, $connectionOptions);

--- a/samples/tutorials/php/2.0 PHP Server programming - Stored procedures, Transactions, and UDFs/test.php
+++ b/samples/tutorials/php/2.0 PHP Server programming - Stored procedures, Transactions, and UDFs/test.php
@@ -94,14 +94,21 @@ if ($getProducts == false) {
     echo "Error deleting the UDF";
     die(FormatErrors(sqlsrv_errors()));
 }
-$tsql1 = "CREATE FUNCTION dbo.ifGetTotalItems (@OrderID INT) RETURNS TABLE WITH SCHEMABINDING AS RETURN (SELECT SUM(OrderQty) AS TotalItems FROM SalesLT.SalesOrderDetail WHERE SalesOrderID = @OrderID GROUP BY SalesOrderID);";
+$tsql1 = 'CREATE FUNCTION dbo.ifGetTotalItems (@OrderID INT) RETURNS TABLE WITH SCHEMABINDING AS RETURN (
+    SELECT SUM(OrderQty) AS TotalItems FROM SalesLT.SalesOrderDetail
+    WHERE SalesOrderID = @OrderID
+    GROUP BY SalesOrderID
+);';
 $getProducts = sqlsrv_query($conn, $tsql1);
 //Error handling
 if ($getProducts == false) {
     echo "Error creating the UDF";
     die(FormatErrors(sqlsrv_errors()));
 }
-$tsql1 = "SELECT s.SalesOrderID, s.OrderDate, s.CustomerID, f.TotalItems FROM SalesLT.SalesOrderHeader s CROSS APPLY dbo.ifGetTotalItems(s.SalesOrderID) f ORDER BY SalesOrderID;";
+$tsql1 = "SELECT s.SalesOrderID, s.OrderDate, s.CustomerID, f.TotalItems
+FROM SalesLT.SalesOrderHeader s
+CROSS APPLY dbo.ifGetTotalItems(s.SalesOrderID) f
+ORDER BY SalesOrderID;";
 $getProducts = sqlsrv_query($conn, $tsql1);
 //Error handling
 if ($getProducts == false) {

--- a/samples/tutorials/php/2.0 PHP Server programming - Stored procedures, Transactions, and UDFs/test.php
+++ b/samples/tutorials/php/2.0 PHP Server programming - Stored procedures, Transactions, and UDFs/test.php
@@ -14,7 +14,7 @@ $conn = sqlsrv_connect($serverName, $connectionOptions);
 
 $tsql = 'CREATE PROCEDURE sp_GetCompanies22 AS BEGIN SELECT [CompanyName] FROM SalesLT.Customer END';
 $storedProc = sqlsrv_query($conn, $tsql);
-if ($storedProc == false) {
+if ($storedProc === false) {
     echo 'Error creating Stored Procedure';
     die(formatErrors(sqlsrv_errors()));
 }
@@ -24,7 +24,7 @@ $tsql = 'exec sp_GETCompanies22';
 // Executes the query
 $getProducts = sqlsrv_query($conn, $tsql);
 // Error handling
-if ($getProducts == false) {
+if ($getProducts === false) {
     echo 'Error executing Stored Procedure';
     die(formatErrors(sqlsrv_errors()));
 }
@@ -47,7 +47,7 @@ sqlsrv_free_stmt($getProducts);
 $tsql = 'DROP PROCEDURE sp_GETCompanies22';
 
 $storedProc = sqlsrv_query($conn, $tsql);
-if ($storedProc == false) {
+if ($storedProc === false) {
     echo 'Error dropping Stored Procedure';
     die(formatErrors(sqlsrv_errors()));
 }
@@ -58,7 +58,7 @@ sqlsrv_free_stmt($storedProc);
  * Transaction
  */
 
-if (sqlsrv_begin_transaction($conn) == false) {
+if (sqlsrv_begin_transaction($conn) === false) {
     echo 'Error opening connection';
     die(formatErrors(sqlsrv_errors()));
 }
@@ -99,7 +99,7 @@ sqlsrv_free_stmt($stmt2);
 $tsql1 = "IF OBJECT_ID(N'dbo.ifGetTotalItems', N'IF') IS NOT NULL DROP FUNCTION dbo.ifGetTotalItems;";
 $getProducts = sqlsrv_query($conn, $tsql1);
 // Error handling
-if ($getProducts == false) {
+if ($getProducts === false) {
     echo 'Error deleting the UDF';
     die(formatErrors(sqlsrv_errors()));
 }
@@ -110,7 +110,7 @@ $tsql1 = 'CREATE FUNCTION dbo.ifGetTotalItems (@OrderID INT) RETURNS TABLE WITH 
 );';
 $getProducts = sqlsrv_query($conn, $tsql1);
 // Error handling
-if ($getProducts == false) {
+if ($getProducts === false) {
     echo 'Error creating the UDF';
     die(formatErrors(sqlsrv_errors()));
 }
@@ -120,7 +120,7 @@ CROSS APPLY dbo.ifGetTotalItems(s.SalesOrderID) f
 ORDER BY SalesOrderID;';
 $getProducts = sqlsrv_query($conn, $tsql1);
 // Error handling
-if ($getProducts == false) {
+if ($getProducts === false) {
     echo 'Error executing the UDF';
     die(formatErrors(sqlsrv_errors()));
 }

--- a/samples/tutorials/php/2.0 PHP Server programming - Stored procedures, Transactions, and UDFs/test.php
+++ b/samples/tutorials/php/2.0 PHP Server programming - Stored procedures, Transactions, and UDFs/test.php
@@ -16,7 +16,8 @@ $tsql = 'CREATE PROCEDURE sp_GetCompanies22 AS BEGIN SELECT [CompanyName] FROM S
 $storedProc = sqlsrv_query($conn, $tsql);
 if ($storedProc === false) {
     echo 'Error creating Stored Procedure';
-    die(format_errors(sqlsrv_errors()));
+    format_errors(sqlsrv_errors());
+    die();
 }
 sqlsrv_free_stmt($storedProc);
 
@@ -26,7 +27,8 @@ $getProducts = sqlsrv_query($conn, $tsql);
 // Error handling
 if ($getProducts === false) {
     echo 'Error executing Stored Procedure';
-    die(format_errors(sqlsrv_errors()));
+    format_errors(sqlsrv_errors());
+    die();
 }
 $productCount = 0;
 $ctr = 0;
@@ -49,7 +51,8 @@ $tsql = 'DROP PROCEDURE sp_GETCompanies22';
 $storedProc = sqlsrv_query($conn, $tsql);
 if ($storedProc === false) {
     echo 'Error dropping Stored Procedure';
-    die(format_errors(sqlsrv_errors()));
+    format_errors(sqlsrv_errors());
+    die();
 }
 sqlsrv_free_stmt($storedProc);
 ?>
@@ -60,7 +63,8 @@ sqlsrv_free_stmt($storedProc);
 
 if (sqlsrv_begin_transaction($conn) === false) {
     echo 'Error opening connection';
-    die(format_errors(sqlsrv_errors()));
+    format_errors(sqlsrv_errors());
+    die();
 }
 
 /* Set up and execute the first query. */
@@ -101,7 +105,8 @@ $getProducts = sqlsrv_query($conn, $tsql1);
 // Error handling
 if ($getProducts === false) {
     echo 'Error deleting the UDF';
-    die(format_errors(sqlsrv_errors()));
+    format_errors(sqlsrv_errors());
+    die();
 }
 $tsql1 = 'CREATE FUNCTION dbo.ifGetTotalItems (@OrderID INT) RETURNS TABLE WITH SCHEMABINDING AS RETURN (
     SELECT SUM(OrderQty) AS TotalItems FROM SalesLT.SalesOrderDetail
@@ -112,7 +117,8 @@ $getProducts = sqlsrv_query($conn, $tsql1);
 // Error handling
 if ($getProducts === false) {
     echo 'Error creating the UDF';
-    die(format_errors(sqlsrv_errors()));
+    format_errors(sqlsrv_errors());
+    die();
 }
 $tsql1 = 'SELECT s.SalesOrderID, s.OrderDate, s.CustomerID, f.TotalItems
 FROM SalesLT.SalesOrderHeader s
@@ -122,7 +128,8 @@ $getProducts = sqlsrv_query($conn, $tsql1);
 // Error handling
 if ($getProducts === false) {
     echo 'Error executing the UDF';
-    die(format_errors(sqlsrv_errors()));
+    format_errors(sqlsrv_errors());
+    die();
 }
 $productCount = 0;
 $ctr = 0;

--- a/samples/tutorials/php/2.0 PHP Server programming - Stored procedures, Transactions, and UDFs/test.php
+++ b/samples/tutorials/php/2.0 PHP Server programming - Stored procedures, Transactions, and UDFs/test.php
@@ -1,9 +1,9 @@
 <?php
-$serverName = "tcp:yourserver.database.windows.net,1433";
+$serverName = 'tcp:yourserver.database.windows.net,1433';
 $connectionOptions = [
-    "Database" => "yourdatabase",
-    "Uid" => "yourusername",
-    "PWD" => "yourpassword",
+    'Database' => 'yourdatabase',
+    'Uid' => 'yourusername',
+    'PWD' => 'yourpassword',
 ];
 // Establishes the connection
 $conn = sqlsrv_connect($serverName, $connectionOptions);
@@ -12,20 +12,20 @@ $conn = sqlsrv_connect($serverName, $connectionOptions);
  * Stored Procedure
  */
 
-$tsql = "CREATE PROCEDURE sp_GetCompanies22 AS BEGIN SELECT [CompanyName] FROM SalesLT.Customer END";
+$tsql = 'CREATE PROCEDURE sp_GetCompanies22 AS BEGIN SELECT [CompanyName] FROM SalesLT.Customer END';
 $storedProc = sqlsrv_query($conn, $tsql);
 if ($storedProc == false) {
-    echo "Error creating Stored Procedure";
+    echo 'Error creating Stored Procedure';
     die(formatErrors(sqlsrv_errors()));
 }
 sqlsrv_free_stmt($storedProc);
 
-$tsql = "exec sp_GETCompanies22";
+$tsql = 'exec sp_GETCompanies22';
 // Executes the query
 $getProducts = sqlsrv_query($conn, $tsql);
 // Error handling
 if ($getProducts == false) {
-    echo "Error executing Stored Procedure";
+    echo 'Error executing Stored Procedure';
     die(formatErrors(sqlsrv_errors()));
 }
 $productCount = 0;
@@ -40,15 +40,15 @@ while ($row = sqlsrv_fetch_array($getProducts, SQLSRV_FETCH_ASSOC)) {
     }
     $ctr++;
     echo($row['CompanyName']);
-    echo("<br/>");
+    echo('<br/>');
     $productCount++;
 }
 sqlsrv_free_stmt($getProducts);
-$tsql = "DROP PROCEDURE sp_GETCompanies22";
+$tsql = 'DROP PROCEDURE sp_GETCompanies22';
 
 $storedProc = sqlsrv_query($conn, $tsql);
 if ($storedProc == false) {
-    echo "Error dropping Stored Procedure";
+    echo 'Error dropping Stored Procedure';
     die(formatErrors(sqlsrv_errors()));
 }
 sqlsrv_free_stmt($storedProc);
@@ -59,18 +59,18 @@ sqlsrv_free_stmt($storedProc);
  */
 
 if (sqlsrv_begin_transaction($conn) == false) {
-    echo "Error opening connection";
+    echo 'Error opening connection';
     die(formatErrors(sqlsrv_errors()));
 }
 
 /* Set up and execute the first query. */
-$tsql1 = "INSERT INTO SalesLT.SalesOrderDetail
+$tsql1 = 'INSERT INTO SalesLT.SalesOrderDetail
        (SalesOrderID,OrderQty,ProductID,UnitPrice)
-       VALUES (71774, 22, 709, 33)";
+       VALUES (71774, 22, 709, 33)';
 $stmt1 = sqlsrv_query($conn, $tsql1);
 
 /* Set up and execute the second query. */
-$tsql2 = "UPDATE SalesLT.SalesOrderDetail SET OrderQty = (OrderQty + 1) WHERE ProductID = 709";
+$tsql2 = 'UPDATE SalesLT.SalesOrderDetail SET OrderQty = (OrderQty + 1) WHERE ProductID = 709';
 $stmt2 = sqlsrv_query($conn, $tsql2);
 
 /* If both queries were successful, commit the transaction. */
@@ -100,7 +100,7 @@ $tsql1 = "IF OBJECT_ID(N'dbo.ifGetTotalItems', N'IF') IS NOT NULL DROP FUNCTION 
 $getProducts = sqlsrv_query($conn, $tsql1);
 // Error handling
 if ($getProducts == false) {
-    echo "Error deleting the UDF";
+    echo 'Error deleting the UDF';
     die(formatErrors(sqlsrv_errors()));
 }
 $tsql1 = 'CREATE FUNCTION dbo.ifGetTotalItems (@OrderID INT) RETURNS TABLE WITH SCHEMABINDING AS RETURN (
@@ -111,17 +111,17 @@ $tsql1 = 'CREATE FUNCTION dbo.ifGetTotalItems (@OrderID INT) RETURNS TABLE WITH 
 $getProducts = sqlsrv_query($conn, $tsql1);
 // Error handling
 if ($getProducts == false) {
-    echo "Error creating the UDF";
+    echo 'Error creating the UDF';
     die(formatErrors(sqlsrv_errors()));
 }
-$tsql1 = "SELECT s.SalesOrderID, s.OrderDate, s.CustomerID, f.TotalItems
+$tsql1 = 'SELECT s.SalesOrderID, s.OrderDate, s.CustomerID, f.TotalItems
 FROM SalesLT.SalesOrderHeader s
 CROSS APPLY dbo.ifGetTotalItems(s.SalesOrderID) f
-ORDER BY SalesOrderID;";
+ORDER BY SalesOrderID;';
 $getProducts = sqlsrv_query($conn, $tsql1);
 // Error handling
 if ($getProducts == false) {
-    echo "Error executing the UDF";
+    echo 'Error executing the UDF';
     die(formatErrors(sqlsrv_errors()));
 }
 $productCount = 0;
@@ -129,8 +129,8 @@ $ctr = 0;
 ?>
     <h1> First 10 results are after executing a query that uses the UDF: </h1>
 <?php
-echo "SalesOrderID      CustomerID      TotalItems";
-echo("<br/>");
+echo 'SalesOrderID      CustomerID      TotalItems';
+echo('<br/>');
 
 while ($row = sqlsrv_fetch_array($getProducts, SQLSRV_FETCH_ASSOC)) {
     // Printing only the top 10 results
@@ -142,7 +142,7 @@ while ($row = sqlsrv_fetch_array($getProducts, SQLSRV_FETCH_ASSOC)) {
         '&nbsp;',
         11
     ) . $row['TotalItems'];
-    echo("<br/>");
+    echo('<br/>');
     $productCount++;
 }
 sqlsrv_free_stmt($getProducts);

--- a/samples/tutorials/php/2.0 PHP Server programming - Stored procedures, Transactions, and UDFs/test.php
+++ b/samples/tutorials/php/2.0 PHP Server programming - Stored procedures, Transactions, and UDFs/test.php
@@ -16,7 +16,7 @@ $tsql = 'CREATE PROCEDURE sp_GetCompanies22 AS BEGIN SELECT [CompanyName] FROM S
 $storedProc = sqlsrv_query($conn, $tsql);
 if ($storedProc === false) {
     echo 'Error creating Stored Procedure';
-    die(formatErrors(sqlsrv_errors()));
+    die(format_errors(sqlsrv_errors()));
 }
 sqlsrv_free_stmt($storedProc);
 
@@ -26,7 +26,7 @@ $getProducts = sqlsrv_query($conn, $tsql);
 // Error handling
 if ($getProducts === false) {
     echo 'Error executing Stored Procedure';
-    die(formatErrors(sqlsrv_errors()));
+    die(format_errors(sqlsrv_errors()));
 }
 $productCount = 0;
 $ctr = 0;
@@ -49,7 +49,7 @@ $tsql = 'DROP PROCEDURE sp_GETCompanies22';
 $storedProc = sqlsrv_query($conn, $tsql);
 if ($storedProc === false) {
     echo 'Error dropping Stored Procedure';
-    die(formatErrors(sqlsrv_errors()));
+    die(format_errors(sqlsrv_errors()));
 }
 sqlsrv_free_stmt($storedProc);
 ?>
@@ -60,7 +60,7 @@ sqlsrv_free_stmt($storedProc);
 
 if (sqlsrv_begin_transaction($conn) === false) {
     echo 'Error opening connection';
-    die(formatErrors(sqlsrv_errors()));
+    die(format_errors(sqlsrv_errors()));
 }
 
 /* Set up and execute the first query. */
@@ -101,7 +101,7 @@ $getProducts = sqlsrv_query($conn, $tsql1);
 // Error handling
 if ($getProducts === false) {
     echo 'Error deleting the UDF';
-    die(formatErrors(sqlsrv_errors()));
+    die(format_errors(sqlsrv_errors()));
 }
 $tsql1 = 'CREATE FUNCTION dbo.ifGetTotalItems (@OrderID INT) RETURNS TABLE WITH SCHEMABINDING AS RETURN (
     SELECT SUM(OrderQty) AS TotalItems FROM SalesLT.SalesOrderDetail
@@ -112,7 +112,7 @@ $getProducts = sqlsrv_query($conn, $tsql1);
 // Error handling
 if ($getProducts === false) {
     echo 'Error creating the UDF';
-    die(formatErrors(sqlsrv_errors()));
+    die(format_errors(sqlsrv_errors()));
 }
 $tsql1 = 'SELECT s.SalesOrderID, s.OrderDate, s.CustomerID, f.TotalItems
 FROM SalesLT.SalesOrderHeader s
@@ -122,7 +122,7 @@ $getProducts = sqlsrv_query($conn, $tsql1);
 // Error handling
 if ($getProducts === false) {
     echo 'Error executing the UDF';
-    die(formatErrors(sqlsrv_errors()));
+    die(format_errors(sqlsrv_errors()));
 }
 $productCount = 0;
 $ctr = 0;

--- a/samples/tutorials/php/RHEL/SqlServerColumnstoreSample/columnstore.php
+++ b/samples/tutorials/php/RHEL/SqlServerColumnstoreSample/columnstore.php
@@ -1,5 +1,5 @@
 <?php
-$time_start = microtime(true);
+$timeStart = microtime(true);
 
 $serverName = "localhost";
 $connectionOptions = [
@@ -34,6 +34,6 @@ function formatErrors($errors)
     }
 }
 
-$time_end = microtime(true);
-$execution_time = round((($time_end - $time_start) * 1000), 2);
-echo 'QueryTime: ' . $execution_time . ' ms';
+$timeEnd = microtime(true);
+$executionTime = round((($timeEnd - $timeStart) * 1000), 2);
+echo 'QueryTime: ' . $executionTime . ' ms';

--- a/samples/tutorials/php/RHEL/SqlServerColumnstoreSample/columnstore.php
+++ b/samples/tutorials/php/RHEL/SqlServerColumnstoreSample/columnstore.php
@@ -15,7 +15,8 @@ $tsql = 'SELECT SUM(Price) as sum FROM Table_with_5M_rows';
 $getResults = sqlsrv_query($conn, $tsql);
 echo('Sum: ');
 if ($getResults === false) {
-    die(format_errors(sqlsrv_errors()));
+    format_errors(sqlsrv_errors());
+    die();
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
     echo($row['sum'] . PHP_EOL);

--- a/samples/tutorials/php/RHEL/SqlServerColumnstoreSample/columnstore.php
+++ b/samples/tutorials/php/RHEL/SqlServerColumnstoreSample/columnstore.php
@@ -14,7 +14,7 @@ $conn = sqlsrv_connect($serverName, $connectionOptions);
 $tsql = 'SELECT SUM(Price) as sum FROM Table_with_5M_rows';
 $getResults = sqlsrv_query($conn, $tsql);
 echo('Sum: ');
-if ($getResults == false) {
+if ($getResults === false) {
     die(formatErrors(sqlsrv_errors()));
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {

--- a/samples/tutorials/php/RHEL/SqlServerColumnstoreSample/columnstore.php
+++ b/samples/tutorials/php/RHEL/SqlServerColumnstoreSample/columnstore.php
@@ -15,14 +15,14 @@ $tsql = "SELECT SUM(Price) as sum FROM Table_with_5M_rows";
 $getResults = sqlsrv_query($conn, $tsql);
 echo("Sum: ");
 if ($getResults == false) {
-    die(FormatErrors(sqlsrv_errors()));
+    die(formatErrors(sqlsrv_errors()));
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
     echo($row['sum'] . PHP_EOL);
 }
 sqlsrv_free_stmt($getResults);
 
-function FormatErrors($errors)
+function formatErrors($errors)
 {
     /* Display errors. */
     echo "Error information: ";

--- a/samples/tutorials/php/RHEL/SqlServerColumnstoreSample/columnstore.php
+++ b/samples/tutorials/php/RHEL/SqlServerColumnstoreSample/columnstore.php
@@ -2,41 +2,39 @@
 $time_start = microtime(true);
 
 $serverName = "localhost";
-$connectionOptions = array(
+$connectionOptions = [
     "Database" => "SampleDB",
     "Uid" => "sa",
-    "PWD" => "your_password"
-);
+    "PWD" => "your_password",
+];
 //Establishes the connection
 $conn = sqlsrv_connect($serverName, $connectionOptions);
 
 //Read Query
-$tsql= "SELECT SUM(Price) as sum FROM Table_with_5M_rows";
-$getResults= sqlsrv_query($conn, $tsql);
-echo ("Sum: ");
-if ($getResults == FALSE)
+$tsql = "SELECT SUM(Price) as sum FROM Table_with_5M_rows";
+$getResults = sqlsrv_query($conn, $tsql);
+echo("Sum: ");
+if ($getResults == false) {
     die(FormatErrors(sqlsrv_errors()));
+}
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
-    echo ($row['sum'] . PHP_EOL);
+    echo($row['sum'] . PHP_EOL);
 
 }
 sqlsrv_free_stmt($getResults);
 
-function FormatErrors( $errors )
+function FormatErrors($errors)
 {
     /* Display errors. */
     echo "Error information: ";
 
-    foreach ( $errors as $error )
-    {
-        echo "SQLSTATE: ".$error['SQLSTATE']."";
-        echo "Code: ".$error['code']."";
-        echo "Message: ".$error['message']."";
+    foreach ($errors as $error) {
+        echo "SQLSTATE: " . $error['SQLSTATE'] . "";
+        echo "Code: " . $error['code'] . "";
+        echo "Message: " . $error['message'] . "";
     }
 }
+
 $time_end = microtime(true);
-$execution_time = round((($time_end - $time_start)*1000),2);
-echo 'QueryTime: '.$execution_time.' ms';
-
-
-?>
+$execution_time = round((($time_end - $time_start) * 1000), 2);
+echo 'QueryTime: ' . $execution_time . ' ms';

--- a/samples/tutorials/php/RHEL/SqlServerColumnstoreSample/columnstore.php
+++ b/samples/tutorials/php/RHEL/SqlServerColumnstoreSample/columnstore.php
@@ -1,19 +1,19 @@
 <?php
 $timeStart = microtime(true);
 
-$serverName = "localhost";
+$serverName = 'localhost';
 $connectionOptions = [
-    "Database" => "SampleDB",
-    "Uid" => "sa",
-    "PWD" => "your_password",
+    'Database' => 'SampleDB',
+    'Uid' => 'sa',
+    'PWD' => 'your_password',
 ];
 // Establishes the connection
 $conn = sqlsrv_connect($serverName, $connectionOptions);
 
 // Read Query
-$tsql = "SELECT SUM(Price) as sum FROM Table_with_5M_rows";
+$tsql = 'SELECT SUM(Price) as sum FROM Table_with_5M_rows';
 $getResults = sqlsrv_query($conn, $tsql);
-echo("Sum: ");
+echo('Sum: ');
 if ($getResults == false) {
     die(formatErrors(sqlsrv_errors()));
 }
@@ -25,12 +25,12 @@ sqlsrv_free_stmt($getResults);
 function formatErrors($errors)
 {
     /* Display errors. */
-    echo "Error information: ";
+    echo 'Error information: ';
 
     foreach ($errors as $error) {
-        echo "SQLSTATE: " . $error['SQLSTATE'] . "";
-        echo "Code: " . $error['code'] . "";
-        echo "Message: " . $error['message'] . "";
+        echo 'SQLSTATE: ' . $error['SQLSTATE'] . '';
+        echo 'Code: ' . $error['code'] . '';
+        echo 'Message: ' . $error['message'] . '';
     }
 }
 

--- a/samples/tutorials/php/RHEL/SqlServerColumnstoreSample/columnstore.php
+++ b/samples/tutorials/php/RHEL/SqlServerColumnstoreSample/columnstore.php
@@ -7,10 +7,10 @@ $connectionOptions = [
     "Uid" => "sa",
     "PWD" => "your_password",
 ];
-//Establishes the connection
+// Establishes the connection
 $conn = sqlsrv_connect($serverName, $connectionOptions);
 
-//Read Query
+// Read Query
 $tsql = "SELECT SUM(Price) as sum FROM Table_with_5M_rows";
 $getResults = sqlsrv_query($conn, $tsql);
 echo("Sum: ");

--- a/samples/tutorials/php/RHEL/SqlServerColumnstoreSample/columnstore.php
+++ b/samples/tutorials/php/RHEL/SqlServerColumnstoreSample/columnstore.php
@@ -15,14 +15,14 @@ $tsql = 'SELECT SUM(Price) as sum FROM Table_with_5M_rows';
 $getResults = sqlsrv_query($conn, $tsql);
 echo('Sum: ');
 if ($getResults === false) {
-    die(formatErrors(sqlsrv_errors()));
+    die(format_errors(sqlsrv_errors()));
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
     echo($row['sum'] . PHP_EOL);
 }
 sqlsrv_free_stmt($getResults);
 
-function formatErrors($errors)
+function format_errors($errors)
 {
     /* Display errors. */
     echo 'Error information: ';

--- a/samples/tutorials/php/RHEL/SqlServerColumnstoreSample/columnstore.php
+++ b/samples/tutorials/php/RHEL/SqlServerColumnstoreSample/columnstore.php
@@ -19,7 +19,6 @@ if ($getResults == false) {
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
     echo($row['sum'] . PHP_EOL);
-
 }
 sqlsrv_free_stmt($getResults);
 

--- a/samples/tutorials/php/RHEL/SqlServerSample/connect.php
+++ b/samples/tutorials/php/RHEL/SqlServerSample/connect.php
@@ -1,12 +1,12 @@
 <?php
-$serverName = "localhost";
+$serverName = 'localhost';
 $connectionOptions = [
-    "Database" => "SampleDB",
-    "Uid" => "sa",
-    "PWD" => "your_password",
+    'Database' => 'SampleDB',
+    'Uid' => 'sa',
+    'PWD' => 'your_password',
 ];
 // Establishes the connection
 $conn = sqlsrv_connect($serverName, $connectionOptions);
 if ($conn) {
-    echo "Connected!";
+    echo 'Connected!';
 }

--- a/samples/tutorials/php/RHEL/SqlServerSample/connect.php
+++ b/samples/tutorials/php/RHEL/SqlServerSample/connect.php
@@ -1,12 +1,12 @@
 <?php
 $serverName = "localhost";
-$connectionOptions = array(
+$connectionOptions = [
     "Database" => "SampleDB",
     "Uid" => "sa",
-    "PWD" => "your_password"
-);
+    "PWD" => "your_password",
+];
 //Establishes the connection
 $conn = sqlsrv_connect($serverName, $connectionOptions);
-if($conn)
-    echo "Connected!"
-?>
+if ($conn) {
+    echo "Connected!";
+}

--- a/samples/tutorials/php/RHEL/SqlServerSample/connect.php
+++ b/samples/tutorials/php/RHEL/SqlServerSample/connect.php
@@ -5,7 +5,7 @@ $connectionOptions = [
     "Uid" => "sa",
     "PWD" => "your_password",
 ];
-//Establishes the connection
+// Establishes the connection
 $conn = sqlsrv_connect($serverName, $connectionOptions);
 if ($conn) {
     echo "Connected!";

--- a/samples/tutorials/php/RHEL/SqlServerSample/crud.php
+++ b/samples/tutorials/php/RHEL/SqlServerSample/crud.php
@@ -26,7 +26,7 @@ sqlsrv_free_stmt($getResults);
 
 $userToUpdate = 'Nikita';
 $tsql = 'UPDATE TestSchema.Employees SET Location = ? WHERE Name = ?';
-$params = ['Sweeden', $userToUpdate];
+$params = ['Sweden', $userToUpdate];
 echo('Updating Location for user ' . $userToUpdate . PHP_EOL);
 
 $getResults = sqlsrv_query($conn, $tsql, $params);
@@ -38,7 +38,7 @@ if ($getResults === false || $rowsAffected === false) {
 echo($rowsAffected . ' row(s) updated: ' . PHP_EOL);
 sqlsrv_free_stmt($getResults);
 
-// Delte Query
+//  Delete Query
 $userToDelete = 'Jared';
 $tsql = 'DELETE FROM TestSchema.Employees WHERE Name = ?';
 $params = [$userToDelete];

--- a/samples/tutorials/php/RHEL/SqlServerSample/crud.php
+++ b/samples/tutorials/php/RHEL/SqlServerSample/crud.php
@@ -14,7 +14,7 @@ $tsql = "INSERT INTO TestSchema.Employees (Name, Location) VALUES (?,?);";
 $params = ['Jake', 'United States'];
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
-if ($getResults == false or $rowsAffected == false) {
+if ($getResults == false || $rowsAffected == false) {
     die(FormatErrors(sqlsrv_errors()));
 }
 echo($rowsAffected . " row(s) inserted: " . PHP_EOL);
@@ -30,7 +30,7 @@ echo("Updating Location for user " . $userToUpdate . PHP_EOL);
 
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
-if ($getResults == false or $rowsAffected == false) {
+if ($getResults == false || $rowsAffected == false) {
     die(FormatErrors(sqlsrv_errors()));
 }
 echo($rowsAffected . " row(s) updated: " . PHP_EOL);
@@ -43,7 +43,7 @@ $params = [$userToDelete];
 $getResults = sqlsrv_query($conn, $tsql, $params);
 echo("Deleting user " . $userToDelete . PHP_EOL);
 $rowsAffected = sqlsrv_rows_affected($getResults);
-if ($getResults == false or $rowsAffected == false) {
+if ($getResults == false || $rowsAffected == false) {
     die(FormatErrors(sqlsrv_errors()));
 }
 echo($rowsAffected . " row(s) deleted: " . PHP_EOL);

--- a/samples/tutorials/php/RHEL/SqlServerSample/crud.php
+++ b/samples/tutorials/php/RHEL/SqlServerSample/crud.php
@@ -5,10 +5,10 @@ $connectionOptions = [
     "Uid" => "sa",
     "PWD" => "your_password",
 ];
-//Establishes the connection
+// Establishes the connection
 $conn = sqlsrv_connect($serverName, $connectionOptions);
 
-//Insert Query
+// Insert Query
 echo("Inserting a new row into table" . PHP_EOL);
 $tsql = "INSERT INTO TestSchema.Employees (Name, Location) VALUES (?,?);";
 $params = ['Jake', 'United States'];
@@ -21,7 +21,7 @@ echo($rowsAffected . " row(s) inserted: " . PHP_EOL);
 
 sqlsrv_free_stmt($getResults);
 
-//Update Query
+// Update Query
 
 $userToUpdate = 'Nikita';
 $tsql = "UPDATE TestSchema.Employees SET Location = ? WHERE Name = ?";
@@ -36,7 +36,7 @@ if ($getResults == false || $rowsAffected == false) {
 echo($rowsAffected . " row(s) updated: " . PHP_EOL);
 sqlsrv_free_stmt($getResults);
 
-//Delte Query
+// Delte Query
 $userToDelete = 'Jared';
 $tsql = "DELETE FROM TestSchema.Employees WHERE Name = ?";
 $params = [$userToDelete];
@@ -49,7 +49,7 @@ if ($getResults == false || $rowsAffected == false) {
 echo($rowsAffected . " row(s) deleted: " . PHP_EOL);
 sqlsrv_free_stmt($getResults);
 
-//Read Query
+// Read Query
 $tsql = "SELECT Id, Name, Location FROM TestSchema.Employees;";
 $getResults = sqlsrv_query($conn, $tsql);
 echo("Reading data from table" . PHP_EOL);

--- a/samples/tutorials/php/RHEL/SqlServerSample/crud.php
+++ b/samples/tutorials/php/RHEL/SqlServerSample/crud.php
@@ -15,7 +15,8 @@ $params = ['Jake', 'United States'];
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults === false || $rowsAffected === false) {
-    die(format_errors(sqlsrv_errors()));
+    format_errors(sqlsrv_errors());
+    die();
 }
 echo($rowsAffected . ' row(s) inserted: ' . PHP_EOL);
 
@@ -31,7 +32,8 @@ echo('Updating Location for user ' . $userToUpdate . PHP_EOL);
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults === false || $rowsAffected === false) {
-    die(format_errors(sqlsrv_errors()));
+    format_errors(sqlsrv_errors());
+    die();
 }
 echo($rowsAffected . ' row(s) updated: ' . PHP_EOL);
 sqlsrv_free_stmt($getResults);
@@ -44,7 +46,8 @@ $getResults = sqlsrv_query($conn, $tsql, $params);
 echo('Deleting user ' . $userToDelete . PHP_EOL);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults === false || $rowsAffected === false) {
-    die(format_errors(sqlsrv_errors()));
+    format_errors(sqlsrv_errors());
+    die();
 }
 echo($rowsAffected . ' row(s) deleted: ' . PHP_EOL);
 sqlsrv_free_stmt($getResults);
@@ -54,7 +57,8 @@ $tsql = 'SELECT Id, Name, Location FROM TestSchema.Employees;';
 $getResults = sqlsrv_query($conn, $tsql);
 echo('Reading data from table' . PHP_EOL);
 if ($getResults === false) {
-    die(format_errors(sqlsrv_errors()));
+    format_errors(sqlsrv_errors());
+    die();
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
     echo($row['Id'] . ' ' . $row['Name'] . ' ' . $row['Location'] . PHP_EOL);

--- a/samples/tutorials/php/RHEL/SqlServerSample/crud.php
+++ b/samples/tutorials/php/RHEL/SqlServerSample/crud.php
@@ -15,7 +15,7 @@ $params = ['Jake', 'United States'];
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults === false || $rowsAffected === false) {
-    die(formatErrors(sqlsrv_errors()));
+    die(format_errors(sqlsrv_errors()));
 }
 echo($rowsAffected . ' row(s) inserted: ' . PHP_EOL);
 
@@ -31,7 +31,7 @@ echo('Updating Location for user ' . $userToUpdate . PHP_EOL);
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults === false || $rowsAffected === false) {
-    die(formatErrors(sqlsrv_errors()));
+    die(format_errors(sqlsrv_errors()));
 }
 echo($rowsAffected . ' row(s) updated: ' . PHP_EOL);
 sqlsrv_free_stmt($getResults);
@@ -44,7 +44,7 @@ $getResults = sqlsrv_query($conn, $tsql, $params);
 echo('Deleting user ' . $userToDelete . PHP_EOL);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults === false || $rowsAffected === false) {
-    die(formatErrors(sqlsrv_errors()));
+    die(format_errors(sqlsrv_errors()));
 }
 echo($rowsAffected . ' row(s) deleted: ' . PHP_EOL);
 sqlsrv_free_stmt($getResults);
@@ -54,14 +54,14 @@ $tsql = 'SELECT Id, Name, Location FROM TestSchema.Employees;';
 $getResults = sqlsrv_query($conn, $tsql);
 echo('Reading data from table' . PHP_EOL);
 if ($getResults === false) {
-    die(formatErrors(sqlsrv_errors()));
+    die(format_errors(sqlsrv_errors()));
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
     echo($row['Id'] . ' ' . $row['Name'] . ' ' . $row['Location'] . PHP_EOL);
 }
 sqlsrv_free_stmt($getResults);
 
-function formatErrors($errors)
+function format_errors($errors)
 {
     /* Display errors. */
     echo 'Error information: ';

--- a/samples/tutorials/php/RHEL/SqlServerSample/crud.php
+++ b/samples/tutorials/php/RHEL/SqlServerSample/crud.php
@@ -14,7 +14,7 @@ $tsql = 'INSERT INTO TestSchema.Employees (Name, Location) VALUES (?,?);';
 $params = ['Jake', 'United States'];
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
-if ($getResults == false || $rowsAffected == false) {
+if ($getResults === false || $rowsAffected === false) {
     die(formatErrors(sqlsrv_errors()));
 }
 echo($rowsAffected . ' row(s) inserted: ' . PHP_EOL);
@@ -30,7 +30,7 @@ echo('Updating Location for user ' . $userToUpdate . PHP_EOL);
 
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
-if ($getResults == false || $rowsAffected == false) {
+if ($getResults === false || $rowsAffected === false) {
     die(formatErrors(sqlsrv_errors()));
 }
 echo($rowsAffected . ' row(s) updated: ' . PHP_EOL);
@@ -43,7 +43,7 @@ $params = [$userToDelete];
 $getResults = sqlsrv_query($conn, $tsql, $params);
 echo('Deleting user ' . $userToDelete . PHP_EOL);
 $rowsAffected = sqlsrv_rows_affected($getResults);
-if ($getResults == false || $rowsAffected == false) {
+if ($getResults === false || $rowsAffected === false) {
     die(formatErrors(sqlsrv_errors()));
 }
 echo($rowsAffected . ' row(s) deleted: ' . PHP_EOL);
@@ -53,7 +53,7 @@ sqlsrv_free_stmt($getResults);
 $tsql = 'SELECT Id, Name, Location FROM TestSchema.Employees;';
 $getResults = sqlsrv_query($conn, $tsql);
 echo('Reading data from table' . PHP_EOL);
-if ($getResults == false) {
+if ($getResults === false) {
     die(formatErrors(sqlsrv_errors()));
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {

--- a/samples/tutorials/php/RHEL/SqlServerSample/crud.php
+++ b/samples/tutorials/php/RHEL/SqlServerSample/crud.php
@@ -1,74 +1,75 @@
 <?php
 $serverName = "localhost";
-$connectionOptions = array(
+$connectionOptions = [
     "Database" => "SampleDB",
     "Uid" => "sa",
-    "PWD" => "your_password"
-);
+    "PWD" => "your_password",
+];
 //Establishes the connection
 $conn = sqlsrv_connect($serverName, $connectionOptions);
 
 //Insert Query
-echo ("Inserting a new row into table" . PHP_EOL);
-$tsql= "INSERT INTO TestSchema.Employees (Name, Location) VALUES (?,?);";
-$params = array('Jake','United States');
-$getResults= sqlsrv_query($conn, $tsql, $params);
+echo("Inserting a new row into table" . PHP_EOL);
+$tsql = "INSERT INTO TestSchema.Employees (Name, Location) VALUES (?,?);";
+$params = ['Jake', 'United States'];
+$getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
-if ($getResults == FALSE or $rowsAffected == FALSE)
+if ($getResults == false or $rowsAffected == false) {
     die(FormatErrors(sqlsrv_errors()));
-echo ($rowsAffected. " row(s) inserted: " . PHP_EOL);
+}
+echo($rowsAffected . " row(s) inserted: " . PHP_EOL);
 
 sqlsrv_free_stmt($getResults);
 
 //Update Query
 
 $userToUpdate = 'Nikita';
-$tsql= "UPDATE TestSchema.Employees SET Location = ? WHERE Name = ?";
-$params = array('Sweeden', $userToUpdate);
+$tsql = "UPDATE TestSchema.Employees SET Location = ? WHERE Name = ?";
+$params = ['Sweeden', $userToUpdate];
 echo("Updating Location for user " . $userToUpdate . PHP_EOL);
 
-$getResults= sqlsrv_query($conn, $tsql, $params);
+$getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
-if ($getResults == FALSE or $rowsAffected == FALSE)
+if ($getResults == false or $rowsAffected == false) {
     die(FormatErrors(sqlsrv_errors()));
-echo ($rowsAffected. " row(s) updated: " . PHP_EOL);
+}
+echo($rowsAffected . " row(s) updated: " . PHP_EOL);
 sqlsrv_free_stmt($getResults);
 
 //Delte Query
 $userToDelete = 'Jared';
-$tsql= "DELETE FROM TestSchema.Employees WHERE Name = ?";
-$params = array($userToDelete);
-$getResults= sqlsrv_query($conn, $tsql, $params);
+$tsql = "DELETE FROM TestSchema.Employees WHERE Name = ?";
+$params = [$userToDelete];
+$getResults = sqlsrv_query($conn, $tsql, $params);
 echo("Deleting user " . $userToDelete . PHP_EOL);
 $rowsAffected = sqlsrv_rows_affected($getResults);
-if ($getResults == FALSE or $rowsAffected == FALSE)
+if ($getResults == false or $rowsAffected == false) {
     die(FormatErrors(sqlsrv_errors()));
-echo ($rowsAffected. " row(s) deleted: " . PHP_EOL);
+}
+echo($rowsAffected . " row(s) deleted: " . PHP_EOL);
 sqlsrv_free_stmt($getResults);
 
-
 //Read Query
-$tsql= "SELECT Id, Name, Location FROM TestSchema.Employees;";
-$getResults= sqlsrv_query($conn, $tsql);
-echo ("Reading data from table" . PHP_EOL);
-if ($getResults == FALSE)
+$tsql = "SELECT Id, Name, Location FROM TestSchema.Employees;";
+$getResults = sqlsrv_query($conn, $tsql);
+echo("Reading data from table" . PHP_EOL);
+if ($getResults == false) {
     die(FormatErrors(sqlsrv_errors()));
+}
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
-    echo ($row['Id'] . " " . $row['Name'] . " " . $row['Location'] . PHP_EOL);
+    echo($row['Id'] . " " . $row['Name'] . " " . $row['Location'] . PHP_EOL);
 
 }
 sqlsrv_free_stmt($getResults);
 
-function FormatErrors( $errors )
+function FormatErrors($errors)
 {
     /* Display errors. */
     echo "Error information: ";
 
-    foreach ( $errors as $error )
-    {
-        echo "SQLSTATE: ".$error['SQLSTATE']."";
-        echo "Code: ".$error['code']."";
-        echo "Message: ".$error['message']."";
+    foreach ($errors as $error) {
+        echo "SQLSTATE: " . $error['SQLSTATE'] . "";
+        echo "Code: " . $error['code'] . "";
+        echo "Message: " . $error['message'] . "";
     }
 }
-?>

--- a/samples/tutorials/php/RHEL/SqlServerSample/crud.php
+++ b/samples/tutorials/php/RHEL/SqlServerSample/crud.php
@@ -15,7 +15,7 @@ $params = ['Jake', 'United States'];
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults == false || $rowsAffected == false) {
-    die(FormatErrors(sqlsrv_errors()));
+    die(formatErrors(sqlsrv_errors()));
 }
 echo($rowsAffected . " row(s) inserted: " . PHP_EOL);
 
@@ -31,7 +31,7 @@ echo("Updating Location for user " . $userToUpdate . PHP_EOL);
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults == false || $rowsAffected == false) {
-    die(FormatErrors(sqlsrv_errors()));
+    die(formatErrors(sqlsrv_errors()));
 }
 echo($rowsAffected . " row(s) updated: " . PHP_EOL);
 sqlsrv_free_stmt($getResults);
@@ -44,7 +44,7 @@ $getResults = sqlsrv_query($conn, $tsql, $params);
 echo("Deleting user " . $userToDelete . PHP_EOL);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults == false || $rowsAffected == false) {
-    die(FormatErrors(sqlsrv_errors()));
+    die(formatErrors(sqlsrv_errors()));
 }
 echo($rowsAffected . " row(s) deleted: " . PHP_EOL);
 sqlsrv_free_stmt($getResults);
@@ -54,14 +54,14 @@ $tsql = "SELECT Id, Name, Location FROM TestSchema.Employees;";
 $getResults = sqlsrv_query($conn, $tsql);
 echo("Reading data from table" . PHP_EOL);
 if ($getResults == false) {
-    die(FormatErrors(sqlsrv_errors()));
+    die(formatErrors(sqlsrv_errors()));
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
     echo($row['Id'] . " " . $row['Name'] . " " . $row['Location'] . PHP_EOL);
 }
 sqlsrv_free_stmt($getResults);
 
-function FormatErrors($errors)
+function formatErrors($errors)
 {
     /* Display errors. */
     echo "Error information: ";

--- a/samples/tutorials/php/RHEL/SqlServerSample/crud.php
+++ b/samples/tutorials/php/RHEL/SqlServerSample/crud.php
@@ -58,7 +58,6 @@ if ($getResults == false) {
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
     echo($row['Id'] . " " . $row['Name'] . " " . $row['Location'] . PHP_EOL);
-
 }
 sqlsrv_free_stmt($getResults);
 

--- a/samples/tutorials/php/RHEL/SqlServerSample/crud.php
+++ b/samples/tutorials/php/RHEL/SqlServerSample/crud.php
@@ -1,74 +1,74 @@
 <?php
-$serverName = "localhost";
+$serverName = 'localhost';
 $connectionOptions = [
-    "Database" => "SampleDB",
-    "Uid" => "sa",
-    "PWD" => "your_password",
+    'Database' => 'SampleDB',
+    'Uid' => 'sa',
+    'PWD' => 'your_password',
 ];
 // Establishes the connection
 $conn = sqlsrv_connect($serverName, $connectionOptions);
 
 // Insert Query
-echo("Inserting a new row into table" . PHP_EOL);
-$tsql = "INSERT INTO TestSchema.Employees (Name, Location) VALUES (?,?);";
+echo('Inserting a new row into table' . PHP_EOL);
+$tsql = 'INSERT INTO TestSchema.Employees (Name, Location) VALUES (?,?);';
 $params = ['Jake', 'United States'];
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults == false || $rowsAffected == false) {
     die(formatErrors(sqlsrv_errors()));
 }
-echo($rowsAffected . " row(s) inserted: " . PHP_EOL);
+echo($rowsAffected . ' row(s) inserted: ' . PHP_EOL);
 
 sqlsrv_free_stmt($getResults);
 
 // Update Query
 
 $userToUpdate = 'Nikita';
-$tsql = "UPDATE TestSchema.Employees SET Location = ? WHERE Name = ?";
+$tsql = 'UPDATE TestSchema.Employees SET Location = ? WHERE Name = ?';
 $params = ['Sweeden', $userToUpdate];
-echo("Updating Location for user " . $userToUpdate . PHP_EOL);
+echo('Updating Location for user ' . $userToUpdate . PHP_EOL);
 
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults == false || $rowsAffected == false) {
     die(formatErrors(sqlsrv_errors()));
 }
-echo($rowsAffected . " row(s) updated: " . PHP_EOL);
+echo($rowsAffected . ' row(s) updated: ' . PHP_EOL);
 sqlsrv_free_stmt($getResults);
 
 // Delte Query
 $userToDelete = 'Jared';
-$tsql = "DELETE FROM TestSchema.Employees WHERE Name = ?";
+$tsql = 'DELETE FROM TestSchema.Employees WHERE Name = ?';
 $params = [$userToDelete];
 $getResults = sqlsrv_query($conn, $tsql, $params);
-echo("Deleting user " . $userToDelete . PHP_EOL);
+echo('Deleting user ' . $userToDelete . PHP_EOL);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults == false || $rowsAffected == false) {
     die(formatErrors(sqlsrv_errors()));
 }
-echo($rowsAffected . " row(s) deleted: " . PHP_EOL);
+echo($rowsAffected . ' row(s) deleted: ' . PHP_EOL);
 sqlsrv_free_stmt($getResults);
 
 // Read Query
-$tsql = "SELECT Id, Name, Location FROM TestSchema.Employees;";
+$tsql = 'SELECT Id, Name, Location FROM TestSchema.Employees;';
 $getResults = sqlsrv_query($conn, $tsql);
-echo("Reading data from table" . PHP_EOL);
+echo('Reading data from table' . PHP_EOL);
 if ($getResults == false) {
     die(formatErrors(sqlsrv_errors()));
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
-    echo($row['Id'] . " " . $row['Name'] . " " . $row['Location'] . PHP_EOL);
+    echo($row['Id'] . ' ' . $row['Name'] . ' ' . $row['Location'] . PHP_EOL);
 }
 sqlsrv_free_stmt($getResults);
 
 function formatErrors($errors)
 {
     /* Display errors. */
-    echo "Error information: ";
+    echo 'Error information: ';
 
     foreach ($errors as $error) {
-        echo "SQLSTATE: " . $error['SQLSTATE'] . "";
-        echo "Code: " . $error['code'] . "";
-        echo "Message: " . $error['message'] . "";
+        echo 'SQLSTATE: ' . $error['SQLSTATE'] . '';
+        echo 'Code: ' . $error['code'] . '';
+        echo 'Message: ' . $error['message'] . '';
     }
 }

--- a/samples/tutorials/php/Ubuntu/SqlServerColumnstoreSample/columnstore.php
+++ b/samples/tutorials/php/Ubuntu/SqlServerColumnstoreSample/columnstore.php
@@ -1,5 +1,5 @@
 <?php
-$time_start = microtime(true);
+$timeStart = microtime(true);
 
 $serverName = "localhost";
 $connectionOptions = [
@@ -34,6 +34,6 @@ function formatErrors($errors)
     }
 }
 
-$time_end = microtime(true);
-$execution_time = round((($time_end - $time_start) * 1000), 2);
-echo 'QueryTime: ' . $execution_time . ' ms';
+$timeEnd = microtime(true);
+$executionTime = round((($timeEnd - $timeStart) * 1000), 2);
+echo 'QueryTime: ' . $executionTime . ' ms';

--- a/samples/tutorials/php/Ubuntu/SqlServerColumnstoreSample/columnstore.php
+++ b/samples/tutorials/php/Ubuntu/SqlServerColumnstoreSample/columnstore.php
@@ -15,7 +15,8 @@ $tsql = 'SELECT SUM(Price) as sum FROM Table_with_5M_rows';
 $getResults = sqlsrv_query($conn, $tsql);
 echo('Sum: ');
 if ($getResults === false) {
-    die(format_errors(sqlsrv_errors()));
+    format_errors(sqlsrv_errors());
+    die();
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
     echo($row['sum'] . PHP_EOL);

--- a/samples/tutorials/php/Ubuntu/SqlServerColumnstoreSample/columnstore.php
+++ b/samples/tutorials/php/Ubuntu/SqlServerColumnstoreSample/columnstore.php
@@ -14,7 +14,7 @@ $conn = sqlsrv_connect($serverName, $connectionOptions);
 $tsql = 'SELECT SUM(Price) as sum FROM Table_with_5M_rows';
 $getResults = sqlsrv_query($conn, $tsql);
 echo('Sum: ');
-if ($getResults == false) {
+if ($getResults === false) {
     die(formatErrors(sqlsrv_errors()));
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {

--- a/samples/tutorials/php/Ubuntu/SqlServerColumnstoreSample/columnstore.php
+++ b/samples/tutorials/php/Ubuntu/SqlServerColumnstoreSample/columnstore.php
@@ -15,14 +15,14 @@ $tsql = "SELECT SUM(Price) as sum FROM Table_with_5M_rows";
 $getResults = sqlsrv_query($conn, $tsql);
 echo("Sum: ");
 if ($getResults == false) {
-    die(FormatErrors(sqlsrv_errors()));
+    die(formatErrors(sqlsrv_errors()));
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
     echo($row['sum'] . PHP_EOL);
 }
 sqlsrv_free_stmt($getResults);
 
-function FormatErrors($errors)
+function formatErrors($errors)
 {
     /* Display errors. */
     echo "Error information: ";

--- a/samples/tutorials/php/Ubuntu/SqlServerColumnstoreSample/columnstore.php
+++ b/samples/tutorials/php/Ubuntu/SqlServerColumnstoreSample/columnstore.php
@@ -2,41 +2,39 @@
 $time_start = microtime(true);
 
 $serverName = "localhost";
-$connectionOptions = array(
+$connectionOptions = [
     "Database" => "SampleDB",
     "Uid" => "sa",
-    "PWD" => "your_password"
-);
+    "PWD" => "your_password",
+];
 //Establishes the connection
 $conn = sqlsrv_connect($serverName, $connectionOptions);
 
 //Read Query
-$tsql= "SELECT SUM(Price) as sum FROM Table_with_5M_rows";
-$getResults= sqlsrv_query($conn, $tsql);
-echo ("Sum: ");
-if ($getResults == FALSE)
+$tsql = "SELECT SUM(Price) as sum FROM Table_with_5M_rows";
+$getResults = sqlsrv_query($conn, $tsql);
+echo("Sum: ");
+if ($getResults == false) {
     die(FormatErrors(sqlsrv_errors()));
+}
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
-    echo ($row['sum'] . PHP_EOL);
+    echo($row['sum'] . PHP_EOL);
 
 }
 sqlsrv_free_stmt($getResults);
 
-function FormatErrors( $errors )
+function FormatErrors($errors)
 {
     /* Display errors. */
     echo "Error information: ";
 
-    foreach ( $errors as $error )
-    {
-        echo "SQLSTATE: ".$error['SQLSTATE']."";
-        echo "Code: ".$error['code']."";
-        echo "Message: ".$error['message']."";
+    foreach ($errors as $error) {
+        echo "SQLSTATE: " . $error['SQLSTATE'] . "";
+        echo "Code: " . $error['code'] . "";
+        echo "Message: " . $error['message'] . "";
     }
 }
+
 $time_end = microtime(true);
-$execution_time = round((($time_end - $time_start)*1000),2);
-echo 'QueryTime: '.$execution_time.' ms';
-
-
-?>
+$execution_time = round((($time_end - $time_start) * 1000), 2);
+echo 'QueryTime: ' . $execution_time . ' ms';

--- a/samples/tutorials/php/Ubuntu/SqlServerColumnstoreSample/columnstore.php
+++ b/samples/tutorials/php/Ubuntu/SqlServerColumnstoreSample/columnstore.php
@@ -1,19 +1,19 @@
 <?php
 $timeStart = microtime(true);
 
-$serverName = "localhost";
+$serverName = 'localhost';
 $connectionOptions = [
-    "Database" => "SampleDB",
-    "Uid" => "sa",
-    "PWD" => "your_password",
+    'Database' => 'SampleDB',
+    'Uid' => 'sa',
+    'PWD' => 'your_password',
 ];
 // Establishes the connection
 $conn = sqlsrv_connect($serverName, $connectionOptions);
 
 // Read Query
-$tsql = "SELECT SUM(Price) as sum FROM Table_with_5M_rows";
+$tsql = 'SELECT SUM(Price) as sum FROM Table_with_5M_rows';
 $getResults = sqlsrv_query($conn, $tsql);
-echo("Sum: ");
+echo('Sum: ');
 if ($getResults == false) {
     die(formatErrors(sqlsrv_errors()));
 }
@@ -25,12 +25,12 @@ sqlsrv_free_stmt($getResults);
 function formatErrors($errors)
 {
     /* Display errors. */
-    echo "Error information: ";
+    echo 'Error information: ';
 
     foreach ($errors as $error) {
-        echo "SQLSTATE: " . $error['SQLSTATE'] . "";
-        echo "Code: " . $error['code'] . "";
-        echo "Message: " . $error['message'] . "";
+        echo 'SQLSTATE: ' . $error['SQLSTATE'] . '';
+        echo 'Code: ' . $error['code'] . '';
+        echo 'Message: ' . $error['message'] . '';
     }
 }
 

--- a/samples/tutorials/php/Ubuntu/SqlServerColumnstoreSample/columnstore.php
+++ b/samples/tutorials/php/Ubuntu/SqlServerColumnstoreSample/columnstore.php
@@ -7,10 +7,10 @@ $connectionOptions = [
     "Uid" => "sa",
     "PWD" => "your_password",
 ];
-//Establishes the connection
+// Establishes the connection
 $conn = sqlsrv_connect($serverName, $connectionOptions);
 
-//Read Query
+// Read Query
 $tsql = "SELECT SUM(Price) as sum FROM Table_with_5M_rows";
 $getResults = sqlsrv_query($conn, $tsql);
 echo("Sum: ");

--- a/samples/tutorials/php/Ubuntu/SqlServerColumnstoreSample/columnstore.php
+++ b/samples/tutorials/php/Ubuntu/SqlServerColumnstoreSample/columnstore.php
@@ -15,14 +15,14 @@ $tsql = 'SELECT SUM(Price) as sum FROM Table_with_5M_rows';
 $getResults = sqlsrv_query($conn, $tsql);
 echo('Sum: ');
 if ($getResults === false) {
-    die(formatErrors(sqlsrv_errors()));
+    die(format_errors(sqlsrv_errors()));
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
     echo($row['sum'] . PHP_EOL);
 }
 sqlsrv_free_stmt($getResults);
 
-function formatErrors($errors)
+function format_errors($errors)
 {
     /* Display errors. */
     echo 'Error information: ';

--- a/samples/tutorials/php/Ubuntu/SqlServerColumnstoreSample/columnstore.php
+++ b/samples/tutorials/php/Ubuntu/SqlServerColumnstoreSample/columnstore.php
@@ -19,7 +19,6 @@ if ($getResults == false) {
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
     echo($row['sum'] . PHP_EOL);
-
 }
 sqlsrv_free_stmt($getResults);
 

--- a/samples/tutorials/php/Ubuntu/SqlServerSample/connect.php
+++ b/samples/tutorials/php/Ubuntu/SqlServerSample/connect.php
@@ -1,14 +1,14 @@
 <?php
     // Setup the connection
-    $serverName = "localhost";
+    $serverName = 'localhost';
     $connectionOptions = [
-        "Database" => "SampleDB",
-        "Uid" => "sa",
-        "PWD" => "your_password"
+        'Database' => 'SampleDB',
+        'Uid' => 'sa',
+        'PWD' => 'your_password'
     ];
 
     // Establish the connection
     $connection = sqlsrv_connect($serverName, $connectionOptions);
     if ($connection) {
-        echo "Connected!";
+        echo 'Connected!';
     }

--- a/samples/tutorials/php/Ubuntu/SqlServerSample/crud.php
+++ b/samples/tutorials/php/Ubuntu/SqlServerSample/crud.php
@@ -14,7 +14,7 @@ $tsql = "INSERT INTO TestSchema.Employees (Name, Location) VALUES (?,?);";
 $params = ['Jake', 'United States'];
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
-if ($getResults == false or $rowsAffected == false) {
+if ($getResults == false || $rowsAffected == false) {
     die(FormatErrors(sqlsrv_errors()));
 }
 echo($rowsAffected . " row(s) inserted: " . PHP_EOL);
@@ -30,7 +30,7 @@ echo("Updating Location for user " . $userToUpdate . PHP_EOL);
 
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
-if ($getResults == false or $rowsAffected == false) {
+if ($getResults == false || $rowsAffected == false) {
     die(FormatErrors(sqlsrv_errors()));
 }
 echo($rowsAffected . " row(s) updated: " . PHP_EOL);
@@ -43,7 +43,7 @@ $params = [$userToDelete];
 $getResults = sqlsrv_query($conn, $tsql, $params);
 echo("Deleting user " . $userToDelete . PHP_EOL);
 $rowsAffected = sqlsrv_rows_affected($getResults);
-if ($getResults == false or $rowsAffected == false) {
+if ($getResults == false || $rowsAffected == false) {
     die(FormatErrors(sqlsrv_errors()));
 }
 echo($rowsAffected . " row(s) deleted: " . PHP_EOL);

--- a/samples/tutorials/php/Ubuntu/SqlServerSample/crud.php
+++ b/samples/tutorials/php/Ubuntu/SqlServerSample/crud.php
@@ -5,10 +5,10 @@ $connectionOptions = [
     "Uid" => "sa",
     "PWD" => "your_password",
 ];
-//Establishes the connection
+// Establishes the connection
 $conn = sqlsrv_connect($serverName, $connectionOptions);
 
-//Insert Query
+// Insert Query
 echo("Inserting a new row into table" . PHP_EOL);
 $tsql = "INSERT INTO TestSchema.Employees (Name, Location) VALUES (?,?);";
 $params = ['Jake', 'United States'];
@@ -21,7 +21,7 @@ echo($rowsAffected . " row(s) inserted: " . PHP_EOL);
 
 sqlsrv_free_stmt($getResults);
 
-//Update Query
+// Update Query
 
 $userToUpdate = 'Nikita';
 $tsql = "UPDATE TestSchema.Employees SET Location = ? WHERE Name = ?";
@@ -36,7 +36,7 @@ if ($getResults == false || $rowsAffected == false) {
 echo($rowsAffected . " row(s) updated: " . PHP_EOL);
 sqlsrv_free_stmt($getResults);
 
-//Delte Query
+// Delte Query
 $userToDelete = 'Jared';
 $tsql = "DELETE FROM TestSchema.Employees WHERE Name = ?";
 $params = [$userToDelete];
@@ -49,7 +49,7 @@ if ($getResults == false || $rowsAffected == false) {
 echo($rowsAffected . " row(s) deleted: " . PHP_EOL);
 sqlsrv_free_stmt($getResults);
 
-//Read Query
+// Read Query
 $tsql = "SELECT Id, Name, Location FROM TestSchema.Employees;";
 $getResults = sqlsrv_query($conn, $tsql);
 echo("Reading data from table" . PHP_EOL);

--- a/samples/tutorials/php/Ubuntu/SqlServerSample/crud.php
+++ b/samples/tutorials/php/Ubuntu/SqlServerSample/crud.php
@@ -15,7 +15,8 @@ $params = ['Jake', 'United States'];
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults === false || $rowsAffected === false) {
-    die(format_errors(sqlsrv_errors()));
+    format_errors(sqlsrv_errors());
+    die();
 }
 echo($rowsAffected . ' row(s) inserted: ' . PHP_EOL);
 
@@ -31,7 +32,8 @@ echo('Updating Location for user ' . $userToUpdate . PHP_EOL);
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults === false || $rowsAffected === false) {
-    die(format_errors(sqlsrv_errors()));
+    format_errors(sqlsrv_errors());
+    die();
 }
 echo($rowsAffected . ' row(s) updated: ' . PHP_EOL);
 sqlsrv_free_stmt($getResults);
@@ -44,7 +46,8 @@ $getResults = sqlsrv_query($conn, $tsql, $params);
 echo('Deleting user ' . $userToDelete . PHP_EOL);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults === false || $rowsAffected === false) {
-    die(format_errors(sqlsrv_errors()));
+    format_errors(sqlsrv_errors());
+    die();
 }
 echo($rowsAffected . ' row(s) deleted: ' . PHP_EOL);
 sqlsrv_free_stmt($getResults);
@@ -54,7 +57,8 @@ $tsql = 'SELECT Id, Name, Location FROM TestSchema.Employees;';
 $getResults = sqlsrv_query($conn, $tsql);
 echo('Reading data from table' . PHP_EOL);
 if ($getResults === false) {
-    die(format_errors(sqlsrv_errors()));
+    format_errors(sqlsrv_errors());
+    die();
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
     echo($row['Id'] . ' ' . $row['Name'] . ' ' . $row['Location'] . PHP_EOL);

--- a/samples/tutorials/php/Ubuntu/SqlServerSample/crud.php
+++ b/samples/tutorials/php/Ubuntu/SqlServerSample/crud.php
@@ -15,7 +15,7 @@ $params = ['Jake', 'United States'];
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults === false || $rowsAffected === false) {
-    die(formatErrors(sqlsrv_errors()));
+    die(format_errors(sqlsrv_errors()));
 }
 echo($rowsAffected . ' row(s) inserted: ' . PHP_EOL);
 
@@ -31,7 +31,7 @@ echo('Updating Location for user ' . $userToUpdate . PHP_EOL);
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults === false || $rowsAffected === false) {
-    die(formatErrors(sqlsrv_errors()));
+    die(format_errors(sqlsrv_errors()));
 }
 echo($rowsAffected . ' row(s) updated: ' . PHP_EOL);
 sqlsrv_free_stmt($getResults);
@@ -44,7 +44,7 @@ $getResults = sqlsrv_query($conn, $tsql, $params);
 echo('Deleting user ' . $userToDelete . PHP_EOL);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults === false || $rowsAffected === false) {
-    die(formatErrors(sqlsrv_errors()));
+    die(format_errors(sqlsrv_errors()));
 }
 echo($rowsAffected . ' row(s) deleted: ' . PHP_EOL);
 sqlsrv_free_stmt($getResults);
@@ -54,14 +54,14 @@ $tsql = 'SELECT Id, Name, Location FROM TestSchema.Employees;';
 $getResults = sqlsrv_query($conn, $tsql);
 echo('Reading data from table' . PHP_EOL);
 if ($getResults === false) {
-    die(formatErrors(sqlsrv_errors()));
+    die(format_errors(sqlsrv_errors()));
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
     echo($row['Id'] . ' ' . $row['Name'] . ' ' . $row['Location'] . PHP_EOL);
 }
 sqlsrv_free_stmt($getResults);
 
-function formatErrors($errors)
+function format_errors($errors)
 {
     /* Display errors. */
     echo 'Error information: ';

--- a/samples/tutorials/php/Ubuntu/SqlServerSample/crud.php
+++ b/samples/tutorials/php/Ubuntu/SqlServerSample/crud.php
@@ -14,7 +14,7 @@ $tsql = 'INSERT INTO TestSchema.Employees (Name, Location) VALUES (?,?);';
 $params = ['Jake', 'United States'];
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
-if ($getResults == false || $rowsAffected == false) {
+if ($getResults === false || $rowsAffected === false) {
     die(formatErrors(sqlsrv_errors()));
 }
 echo($rowsAffected . ' row(s) inserted: ' . PHP_EOL);
@@ -30,7 +30,7 @@ echo('Updating Location for user ' . $userToUpdate . PHP_EOL);
 
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
-if ($getResults == false || $rowsAffected == false) {
+if ($getResults === false || $rowsAffected === false) {
     die(formatErrors(sqlsrv_errors()));
 }
 echo($rowsAffected . ' row(s) updated: ' . PHP_EOL);
@@ -43,7 +43,7 @@ $params = [$userToDelete];
 $getResults = sqlsrv_query($conn, $tsql, $params);
 echo('Deleting user ' . $userToDelete . PHP_EOL);
 $rowsAffected = sqlsrv_rows_affected($getResults);
-if ($getResults == false || $rowsAffected == false) {
+if ($getResults === false || $rowsAffected === false) {
     die(formatErrors(sqlsrv_errors()));
 }
 echo($rowsAffected . ' row(s) deleted: ' . PHP_EOL);
@@ -53,7 +53,7 @@ sqlsrv_free_stmt($getResults);
 $tsql = 'SELECT Id, Name, Location FROM TestSchema.Employees;';
 $getResults = sqlsrv_query($conn, $tsql);
 echo('Reading data from table' . PHP_EOL);
-if ($getResults == false) {
+if ($getResults === false) {
     die(formatErrors(sqlsrv_errors()));
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {

--- a/samples/tutorials/php/Ubuntu/SqlServerSample/crud.php
+++ b/samples/tutorials/php/Ubuntu/SqlServerSample/crud.php
@@ -26,7 +26,7 @@ sqlsrv_free_stmt($getResults);
 
 $userToUpdate = 'Nikita';
 $tsql = 'UPDATE TestSchema.Employees SET Location = ? WHERE Name = ?';
-$params = ['Sweeden', $userToUpdate];
+$params = ['Sweden', $userToUpdate];
 echo('Updating Location for user ' . $userToUpdate . PHP_EOL);
 
 $getResults = sqlsrv_query($conn, $tsql, $params);
@@ -38,7 +38,7 @@ if ($getResults === false || $rowsAffected === false) {
 echo($rowsAffected . ' row(s) updated: ' . PHP_EOL);
 sqlsrv_free_stmt($getResults);
 
-// Delte Query
+// Delete Query
 $userToDelete = 'Jared';
 $tsql = 'DELETE FROM TestSchema.Employees WHERE Name = ?';
 $params = [$userToDelete];

--- a/samples/tutorials/php/Ubuntu/SqlServerSample/crud.php
+++ b/samples/tutorials/php/Ubuntu/SqlServerSample/crud.php
@@ -1,74 +1,75 @@
 <?php
 $serverName = "localhost";
-$connectionOptions = array(
+$connectionOptions = [
     "Database" => "SampleDB",
     "Uid" => "sa",
-    "PWD" => "your_password"
-);
+    "PWD" => "your_password",
+];
 //Establishes the connection
 $conn = sqlsrv_connect($serverName, $connectionOptions);
 
 //Insert Query
-echo ("Inserting a new row into table" . PHP_EOL);
-$tsql= "INSERT INTO TestSchema.Employees (Name, Location) VALUES (?,?);";
-$params = array('Jake','United States');
-$getResults= sqlsrv_query($conn, $tsql, $params);
+echo("Inserting a new row into table" . PHP_EOL);
+$tsql = "INSERT INTO TestSchema.Employees (Name, Location) VALUES (?,?);";
+$params = ['Jake', 'United States'];
+$getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
-if ($getResults == FALSE or $rowsAffected == FALSE)
+if ($getResults == false or $rowsAffected == false) {
     die(FormatErrors(sqlsrv_errors()));
-echo ($rowsAffected. " row(s) inserted: " . PHP_EOL);
+}
+echo($rowsAffected . " row(s) inserted: " . PHP_EOL);
 
 sqlsrv_free_stmt($getResults);
 
 //Update Query
 
 $userToUpdate = 'Nikita';
-$tsql= "UPDATE TestSchema.Employees SET Location = ? WHERE Name = ?";
-$params = array('Sweeden', $userToUpdate);
+$tsql = "UPDATE TestSchema.Employees SET Location = ? WHERE Name = ?";
+$params = ['Sweeden', $userToUpdate];
 echo("Updating Location for user " . $userToUpdate . PHP_EOL);
 
-$getResults= sqlsrv_query($conn, $tsql, $params);
+$getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
-if ($getResults == FALSE or $rowsAffected == FALSE)
+if ($getResults == false or $rowsAffected == false) {
     die(FormatErrors(sqlsrv_errors()));
-echo ($rowsAffected. " row(s) updated: " . PHP_EOL);
+}
+echo($rowsAffected . " row(s) updated: " . PHP_EOL);
 sqlsrv_free_stmt($getResults);
 
 //Delte Query
 $userToDelete = 'Jared';
-$tsql= "DELETE FROM TestSchema.Employees WHERE Name = ?";
-$params = array($userToDelete);
-$getResults= sqlsrv_query($conn, $tsql, $params);
+$tsql = "DELETE FROM TestSchema.Employees WHERE Name = ?";
+$params = [$userToDelete];
+$getResults = sqlsrv_query($conn, $tsql, $params);
 echo("Deleting user " . $userToDelete . PHP_EOL);
 $rowsAffected = sqlsrv_rows_affected($getResults);
-if ($getResults == FALSE or $rowsAffected == FALSE)
+if ($getResults == false or $rowsAffected == false) {
     die(FormatErrors(sqlsrv_errors()));
-echo ($rowsAffected. " row(s) deleted: " . PHP_EOL);
+}
+echo($rowsAffected . " row(s) deleted: " . PHP_EOL);
 sqlsrv_free_stmt($getResults);
 
-
 //Read Query
-$tsql= "SELECT Id, Name, Location FROM TestSchema.Employees;";
-$getResults= sqlsrv_query($conn, $tsql);
-echo ("Reading data from table" . PHP_EOL);
-if ($getResults == FALSE)
+$tsql = "SELECT Id, Name, Location FROM TestSchema.Employees;";
+$getResults = sqlsrv_query($conn, $tsql);
+echo("Reading data from table" . PHP_EOL);
+if ($getResults == false) {
     die(FormatErrors(sqlsrv_errors()));
+}
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
-    echo ($row['Id'] . " " . $row['Name'] . " " . $row['Location'] . PHP_EOL);
+    echo($row['Id'] . " " . $row['Name'] . " " . $row['Location'] . PHP_EOL);
 
 }
 sqlsrv_free_stmt($getResults);
 
-function FormatErrors( $errors )
+function FormatErrors($errors)
 {
     /* Display errors. */
     echo "Error information: ";
 
-    foreach ( $errors as $error )
-    {
-        echo "SQLSTATE: ".$error['SQLSTATE']."";
-        echo "Code: ".$error['code']."";
-        echo "Message: ".$error['message']."";
+    foreach ($errors as $error) {
+        echo "SQLSTATE: " . $error['SQLSTATE'] . "";
+        echo "Code: " . $error['code'] . "";
+        echo "Message: " . $error['message'] . "";
     }
 }
-?>

--- a/samples/tutorials/php/Ubuntu/SqlServerSample/crud.php
+++ b/samples/tutorials/php/Ubuntu/SqlServerSample/crud.php
@@ -15,7 +15,7 @@ $params = ['Jake', 'United States'];
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults == false || $rowsAffected == false) {
-    die(FormatErrors(sqlsrv_errors()));
+    die(formatErrors(sqlsrv_errors()));
 }
 echo($rowsAffected . " row(s) inserted: " . PHP_EOL);
 
@@ -31,7 +31,7 @@ echo("Updating Location for user " . $userToUpdate . PHP_EOL);
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults == false || $rowsAffected == false) {
-    die(FormatErrors(sqlsrv_errors()));
+    die(formatErrors(sqlsrv_errors()));
 }
 echo($rowsAffected . " row(s) updated: " . PHP_EOL);
 sqlsrv_free_stmt($getResults);
@@ -44,7 +44,7 @@ $getResults = sqlsrv_query($conn, $tsql, $params);
 echo("Deleting user " . $userToDelete . PHP_EOL);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults == false || $rowsAffected == false) {
-    die(FormatErrors(sqlsrv_errors()));
+    die(formatErrors(sqlsrv_errors()));
 }
 echo($rowsAffected . " row(s) deleted: " . PHP_EOL);
 sqlsrv_free_stmt($getResults);
@@ -54,14 +54,14 @@ $tsql = "SELECT Id, Name, Location FROM TestSchema.Employees;";
 $getResults = sqlsrv_query($conn, $tsql);
 echo("Reading data from table" . PHP_EOL);
 if ($getResults == false) {
-    die(FormatErrors(sqlsrv_errors()));
+    die(formatErrors(sqlsrv_errors()));
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
     echo($row['Id'] . " " . $row['Name'] . " " . $row['Location'] . PHP_EOL);
 }
 sqlsrv_free_stmt($getResults);
 
-function FormatErrors($errors)
+function formatErrors($errors)
 {
     /* Display errors. */
     echo "Error information: ";

--- a/samples/tutorials/php/Ubuntu/SqlServerSample/crud.php
+++ b/samples/tutorials/php/Ubuntu/SqlServerSample/crud.php
@@ -58,7 +58,6 @@ if ($getResults == false) {
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
     echo($row['Id'] . " " . $row['Name'] . " " . $row['Location'] . PHP_EOL);
-
 }
 sqlsrv_free_stmt($getResults);
 

--- a/samples/tutorials/php/Ubuntu/SqlServerSample/crud.php
+++ b/samples/tutorials/php/Ubuntu/SqlServerSample/crud.php
@@ -1,74 +1,74 @@
 <?php
-$serverName = "localhost";
+$serverName = 'localhost';
 $connectionOptions = [
-    "Database" => "SampleDB",
-    "Uid" => "sa",
-    "PWD" => "your_password",
+    'Database' => 'SampleDB',
+    'Uid' => 'sa',
+    'PWD' => 'your_password',
 ];
 // Establishes the connection
 $conn = sqlsrv_connect($serverName, $connectionOptions);
 
 // Insert Query
-echo("Inserting a new row into table" . PHP_EOL);
-$tsql = "INSERT INTO TestSchema.Employees (Name, Location) VALUES (?,?);";
+echo('Inserting a new row into table' . PHP_EOL);
+$tsql = 'INSERT INTO TestSchema.Employees (Name, Location) VALUES (?,?);';
 $params = ['Jake', 'United States'];
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults == false || $rowsAffected == false) {
     die(formatErrors(sqlsrv_errors()));
 }
-echo($rowsAffected . " row(s) inserted: " . PHP_EOL);
+echo($rowsAffected . ' row(s) inserted: ' . PHP_EOL);
 
 sqlsrv_free_stmt($getResults);
 
 // Update Query
 
 $userToUpdate = 'Nikita';
-$tsql = "UPDATE TestSchema.Employees SET Location = ? WHERE Name = ?";
+$tsql = 'UPDATE TestSchema.Employees SET Location = ? WHERE Name = ?';
 $params = ['Sweeden', $userToUpdate];
-echo("Updating Location for user " . $userToUpdate . PHP_EOL);
+echo('Updating Location for user ' . $userToUpdate . PHP_EOL);
 
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults == false || $rowsAffected == false) {
     die(formatErrors(sqlsrv_errors()));
 }
-echo($rowsAffected . " row(s) updated: " . PHP_EOL);
+echo($rowsAffected . ' row(s) updated: ' . PHP_EOL);
 sqlsrv_free_stmt($getResults);
 
 // Delte Query
 $userToDelete = 'Jared';
-$tsql = "DELETE FROM TestSchema.Employees WHERE Name = ?";
+$tsql = 'DELETE FROM TestSchema.Employees WHERE Name = ?';
 $params = [$userToDelete];
 $getResults = sqlsrv_query($conn, $tsql, $params);
-echo("Deleting user " . $userToDelete . PHP_EOL);
+echo('Deleting user ' . $userToDelete . PHP_EOL);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults == false || $rowsAffected == false) {
     die(formatErrors(sqlsrv_errors()));
 }
-echo($rowsAffected . " row(s) deleted: " . PHP_EOL);
+echo($rowsAffected . ' row(s) deleted: ' . PHP_EOL);
 sqlsrv_free_stmt($getResults);
 
 // Read Query
-$tsql = "SELECT Id, Name, Location FROM TestSchema.Employees;";
+$tsql = 'SELECT Id, Name, Location FROM TestSchema.Employees;';
 $getResults = sqlsrv_query($conn, $tsql);
-echo("Reading data from table" . PHP_EOL);
+echo('Reading data from table' . PHP_EOL);
 if ($getResults == false) {
     die(formatErrors(sqlsrv_errors()));
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
-    echo($row['Id'] . " " . $row['Name'] . " " . $row['Location'] . PHP_EOL);
+    echo($row['Id'] . ' ' . $row['Name'] . ' ' . $row['Location'] . PHP_EOL);
 }
 sqlsrv_free_stmt($getResults);
 
 function formatErrors($errors)
 {
     /* Display errors. */
-    echo "Error information: ";
+    echo 'Error information: ';
 
     foreach ($errors as $error) {
-        echo "SQLSTATE: " . $error['SQLSTATE'] . "";
-        echo "Code: " . $error['code'] . "";
-        echo "Message: " . $error['message'] . "";
+        echo 'SQLSTATE: ' . $error['SQLSTATE'] . '';
+        echo 'Code: ' . $error['code'] . '';
+        echo 'Message: ' . $error['message'] . '';
     }
 }

--- a/samples/tutorials/php/Windows/SqlServerColumnstoreSample/columnstore.php
+++ b/samples/tutorials/php/Windows/SqlServerColumnstoreSample/columnstore.php
@@ -1,5 +1,5 @@
 <?php
-$time_start = microtime(true);
+$timeStart = microtime(true);
 
 $serverName = "localhost";
 $connectionOptions = [
@@ -34,6 +34,6 @@ function formatErrors($errors)
     }
 }
 
-$time_end = microtime(true);
-$execution_time = round((($time_end - $time_start) * 1000), 2);
-echo 'QueryTime: ' . $execution_time . ' ms';
+$timeEnd = microtime(true);
+$executionTime = round((($timeEnd - $timeStart) * 1000), 2);
+echo 'QueryTime: ' . $executionTime . ' ms';

--- a/samples/tutorials/php/Windows/SqlServerColumnstoreSample/columnstore.php
+++ b/samples/tutorials/php/Windows/SqlServerColumnstoreSample/columnstore.php
@@ -15,7 +15,8 @@ $tsql = 'SELECT SUM(Price) as sum FROM Table_with_5M_rows';
 $getResults = sqlsrv_query($conn, $tsql);
 echo('Sum: ');
 if ($getResults === false) {
-    die(format_errors(sqlsrv_errors()));
+    format_errors(sqlsrv_errors());
+    die();
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
     echo($row['sum'] . PHP_EOL);

--- a/samples/tutorials/php/Windows/SqlServerColumnstoreSample/columnstore.php
+++ b/samples/tutorials/php/Windows/SqlServerColumnstoreSample/columnstore.php
@@ -14,7 +14,7 @@ $conn = sqlsrv_connect($serverName, $connectionOptions);
 $tsql = 'SELECT SUM(Price) as sum FROM Table_with_5M_rows';
 $getResults = sqlsrv_query($conn, $tsql);
 echo('Sum: ');
-if ($getResults == false) {
+if ($getResults === false) {
     die(formatErrors(sqlsrv_errors()));
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {

--- a/samples/tutorials/php/Windows/SqlServerColumnstoreSample/columnstore.php
+++ b/samples/tutorials/php/Windows/SqlServerColumnstoreSample/columnstore.php
@@ -15,14 +15,14 @@ $tsql = "SELECT SUM(Price) as sum FROM Table_with_5M_rows";
 $getResults = sqlsrv_query($conn, $tsql);
 echo("Sum: ");
 if ($getResults == false) {
-    die(FormatErrors(sqlsrv_errors()));
+    die(formatErrors(sqlsrv_errors()));
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
     echo($row['sum'] . PHP_EOL);
 }
 sqlsrv_free_stmt($getResults);
 
-function FormatErrors($errors)
+function formatErrors($errors)
 {
     /* Display errors. */
     echo "Error information: ";

--- a/samples/tutorials/php/Windows/SqlServerColumnstoreSample/columnstore.php
+++ b/samples/tutorials/php/Windows/SqlServerColumnstoreSample/columnstore.php
@@ -2,41 +2,39 @@
 $time_start = microtime(true);
 
 $serverName = "localhost";
-$connectionOptions = array(
+$connectionOptions = [
     "Database" => "SampleDB",
     "Uid" => "sa",
-    "PWD" => "your_password"
-);
+    "PWD" => "your_password",
+];
 //Establishes the connection
 $conn = sqlsrv_connect($serverName, $connectionOptions);
 
 //Read Query
-$tsql= "SELECT SUM(Price) as sum FROM Table_with_5M_rows";
-$getResults= sqlsrv_query($conn, $tsql);
-echo ("Sum: ");
-if ($getResults == FALSE)
+$tsql = "SELECT SUM(Price) as sum FROM Table_with_5M_rows";
+$getResults = sqlsrv_query($conn, $tsql);
+echo("Sum: ");
+if ($getResults == false) {
     die(FormatErrors(sqlsrv_errors()));
+}
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
-    echo ($row['sum'] . PHP_EOL);
+    echo($row['sum'] . PHP_EOL);
 
 }
 sqlsrv_free_stmt($getResults);
 
-function FormatErrors( $errors )
+function FormatErrors($errors)
 {
     /* Display errors. */
     echo "Error information: ";
 
-    foreach ( $errors as $error )
-    {
-        echo "SQLSTATE: ".$error['SQLSTATE']."";
-        echo "Code: ".$error['code']."";
-        echo "Message: ".$error['message']."";
+    foreach ($errors as $error) {
+        echo "SQLSTATE: " . $error['SQLSTATE'] . "";
+        echo "Code: " . $error['code'] . "";
+        echo "Message: " . $error['message'] . "";
     }
 }
+
 $time_end = microtime(true);
-$execution_time = round((($time_end - $time_start)*1000),2);
-echo 'QueryTime: '.$execution_time.' ms';
-
-
-?>
+$execution_time = round((($time_end - $time_start) * 1000), 2);
+echo 'QueryTime: ' . $execution_time . ' ms';

--- a/samples/tutorials/php/Windows/SqlServerColumnstoreSample/columnstore.php
+++ b/samples/tutorials/php/Windows/SqlServerColumnstoreSample/columnstore.php
@@ -1,19 +1,19 @@
 <?php
 $timeStart = microtime(true);
 
-$serverName = "localhost";
+$serverName = 'localhost';
 $connectionOptions = [
-    "Database" => "SampleDB",
-    "Uid" => "sa",
-    "PWD" => "your_password",
+    'Database' => 'SampleDB',
+    'Uid' => 'sa',
+    'PWD' => 'your_password',
 ];
 // Establishes the connection
 $conn = sqlsrv_connect($serverName, $connectionOptions);
 
 // Read Query
-$tsql = "SELECT SUM(Price) as sum FROM Table_with_5M_rows";
+$tsql = 'SELECT SUM(Price) as sum FROM Table_with_5M_rows';
 $getResults = sqlsrv_query($conn, $tsql);
-echo("Sum: ");
+echo('Sum: ');
 if ($getResults == false) {
     die(formatErrors(sqlsrv_errors()));
 }
@@ -25,12 +25,12 @@ sqlsrv_free_stmt($getResults);
 function formatErrors($errors)
 {
     /* Display errors. */
-    echo "Error information: ";
+    echo 'Error information: ';
 
     foreach ($errors as $error) {
-        echo "SQLSTATE: " . $error['SQLSTATE'] . "";
-        echo "Code: " . $error['code'] . "";
-        echo "Message: " . $error['message'] . "";
+        echo 'SQLSTATE: ' . $error['SQLSTATE'] . '';
+        echo 'Code: ' . $error['code'] . '';
+        echo 'Message: ' . $error['message'] . '';
     }
 }
 

--- a/samples/tutorials/php/Windows/SqlServerColumnstoreSample/columnstore.php
+++ b/samples/tutorials/php/Windows/SqlServerColumnstoreSample/columnstore.php
@@ -7,10 +7,10 @@ $connectionOptions = [
     "Uid" => "sa",
     "PWD" => "your_password",
 ];
-//Establishes the connection
+// Establishes the connection
 $conn = sqlsrv_connect($serverName, $connectionOptions);
 
-//Read Query
+// Read Query
 $tsql = "SELECT SUM(Price) as sum FROM Table_with_5M_rows";
 $getResults = sqlsrv_query($conn, $tsql);
 echo("Sum: ");

--- a/samples/tutorials/php/Windows/SqlServerColumnstoreSample/columnstore.php
+++ b/samples/tutorials/php/Windows/SqlServerColumnstoreSample/columnstore.php
@@ -15,14 +15,14 @@ $tsql = 'SELECT SUM(Price) as sum FROM Table_with_5M_rows';
 $getResults = sqlsrv_query($conn, $tsql);
 echo('Sum: ');
 if ($getResults === false) {
-    die(formatErrors(sqlsrv_errors()));
+    die(format_errors(sqlsrv_errors()));
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
     echo($row['sum'] . PHP_EOL);
 }
 sqlsrv_free_stmt($getResults);
 
-function formatErrors($errors)
+function format_errors($errors)
 {
     /* Display errors. */
     echo 'Error information: ';

--- a/samples/tutorials/php/Windows/SqlServerColumnstoreSample/columnstore.php
+++ b/samples/tutorials/php/Windows/SqlServerColumnstoreSample/columnstore.php
@@ -19,7 +19,6 @@ if ($getResults == false) {
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
     echo($row['sum'] . PHP_EOL);
-
 }
 sqlsrv_free_stmt($getResults);
 

--- a/samples/tutorials/php/Windows/SqlServerSample/connect.php
+++ b/samples/tutorials/php/Windows/SqlServerSample/connect.php
@@ -1,12 +1,12 @@
 <?php
-$serverName = "localhost";
+$serverName = 'localhost';
 $connectionOptions = [
-    "Database" => "SampleDB",
-    "Uid" => "sa",
-    "PWD" => "your_password",
+    'Database' => 'SampleDB',
+    'Uid' => 'sa',
+    'PWD' => 'your_password',
 ];
 // Establishes the connection
 $conn = sqlsrv_connect($serverName, $connectionOptions);
 if ($conn) {
-    echo "Connected!";
+    echo 'Connected!';
 }

--- a/samples/tutorials/php/Windows/SqlServerSample/connect.php
+++ b/samples/tutorials/php/Windows/SqlServerSample/connect.php
@@ -1,12 +1,12 @@
 <?php
 $serverName = "localhost";
-$connectionOptions = array(
+$connectionOptions = [
     "Database" => "SampleDB",
     "Uid" => "sa",
-    "PWD" => "your_password"
-);
+    "PWD" => "your_password",
+];
 //Establishes the connection
 $conn = sqlsrv_connect($serverName, $connectionOptions);
-if($conn)
-    echo "Connected!"
-?>
+if ($conn) {
+    echo "Connected!";
+}

--- a/samples/tutorials/php/Windows/SqlServerSample/connect.php
+++ b/samples/tutorials/php/Windows/SqlServerSample/connect.php
@@ -5,7 +5,7 @@ $connectionOptions = [
     "Uid" => "sa",
     "PWD" => "your_password",
 ];
-//Establishes the connection
+// Establishes the connection
 $conn = sqlsrv_connect($serverName, $connectionOptions);
 if ($conn) {
     echo "Connected!";

--- a/samples/tutorials/php/Windows/SqlServerSample/crud.php
+++ b/samples/tutorials/php/Windows/SqlServerSample/crud.php
@@ -14,7 +14,7 @@ $tsql = "INSERT INTO TestSchema.Employees (Name, Location) VALUES (?,?);";
 $params = ['Jake', 'United States'];
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
-if ($getResults == false or $rowsAffected == false) {
+if ($getResults == false || $rowsAffected == false) {
     die(FormatErrors(sqlsrv_errors()));
 }
 echo($rowsAffected . " row(s) inserted: " . PHP_EOL);
@@ -30,7 +30,7 @@ echo("Updating Location for user " . $userToUpdate . PHP_EOL);
 
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
-if ($getResults == false or $rowsAffected == false) {
+if ($getResults == false || $rowsAffected == false) {
     die(FormatErrors(sqlsrv_errors()));
 }
 echo($rowsAffected . " row(s) updated: " . PHP_EOL);
@@ -43,7 +43,7 @@ $params = [$userToDelete];
 $getResults = sqlsrv_query($conn, $tsql, $params);
 echo("Deleting user " . $userToDelete . PHP_EOL);
 $rowsAffected = sqlsrv_rows_affected($getResults);
-if ($getResults == false or $rowsAffected == false) {
+if ($getResults == false || $rowsAffected == false) {
     die(FormatErrors(sqlsrv_errors()));
 }
 echo($rowsAffected . " row(s) deleted: " . PHP_EOL);

--- a/samples/tutorials/php/Windows/SqlServerSample/crud.php
+++ b/samples/tutorials/php/Windows/SqlServerSample/crud.php
@@ -1,74 +1,74 @@
 <?php
-$serverName = "localhost";
+$serverName = 'localhost';
 $connectionOptions = [
-    "Database" => "SampleDB",
-    "Uid" => "sa",
-    "PWD" => "your_password",
+    'Database' => 'SampleDB',
+    'Uid' => 'sa',
+    'PWD' => 'your_password',
 ];
 // Establishes the connection
 $conn = sqlsrv_connect($serverName, $connectionOptions);
 
 // Insert Query
-echo("Inserting a new row into table" . PHP_EOL);
-$tsql = "INSERT INTO TestSchema.Employees (Name, Location) VALUES (?,?);";
+echo('Inserting a new row into table' . PHP_EOL);
+$tsql = 'INSERT INTO TestSchema.Employees (Name, Location) VALUES (?,?);';
 $params = ['Jake', 'United States'];
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults == false || $rowsAffected == false) {
     die(formatErrors(sqlsrv_errors()));
 }
-echo($rowsAffected . " row(s) inserted: " . PHP_EOL);
+echo($rowsAffected . ' row(s) inserted: ' . PHP_EOL);
 
 sqlsrv_free_stmt($getResults);
 
 // Update Query
 
 $userToUpdate = 'Nikita';
-$tsql = "UPDATE TestSchema.Employees SET Location = ? WHERE Name = ?";
+$tsql = 'UPDATE TestSchema.Employees SET Location = ? WHERE Name = ?';
 $params = ['Sweeden', $userToUpdate];
-echo("Updating Location for user " . $userToUpdate . PHP_EOL);
+echo('Updating Location for user ' . $userToUpdate . PHP_EOL);
 
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults == false || $rowsAffected == false) {
     die(formatErrors(sqlsrv_errors()));
 }
-echo($rowsAffected . " row(s) updated: " . PHP_EOL);
+echo($rowsAffected . ' row(s) updated: ' . PHP_EOL);
 sqlsrv_free_stmt($getResults);
 
 // Delete Query
 $userToDelete = 'Jared';
-$tsql = "DELETE FROM TestSchema.Employees WHERE Name = ?";
+$tsql = 'DELETE FROM TestSchema.Employees WHERE Name = ?';
 $params = [$userToDelete];
 $getResults = sqlsrv_query($conn, $tsql, $params);
-echo("Deleting user " . $userToDelete . PHP_EOL);
+echo('Deleting user ' . $userToDelete . PHP_EOL);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults == false || $rowsAffected == false) {
     die(formatErrors(sqlsrv_errors()));
 }
-echo($rowsAffected . " row(s) deleted: " . PHP_EOL);
+echo($rowsAffected . ' row(s) deleted: ' . PHP_EOL);
 sqlsrv_free_stmt($getResults);
 
 // Read Query
-$tsql = "SELECT Id, Name, Location FROM TestSchema.Employees;";
+$tsql = 'SELECT Id, Name, Location FROM TestSchema.Employees;';
 $getResults = sqlsrv_query($conn, $tsql);
-echo("Reading data from table" . PHP_EOL);
+echo('Reading data from table' . PHP_EOL);
 if ($getResults == false) {
     die(formatErrors(sqlsrv_errors()));
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
-    echo($row['Id'] . " " . $row['Name'] . " " . $row['Location'] . PHP_EOL);
+    echo($row['Id'] . ' ' . $row['Name'] . ' ' . $row['Location'] . PHP_EOL);
 }
 sqlsrv_free_stmt($getResults);
 
 function formatErrors($errors)
 {
     /* Display errors. */
-    echo "Error information: ";
+    echo 'Error information: ';
 
     foreach ($errors as $error) {
-        echo "SQLSTATE: " . $error['SQLSTATE'] . "";
-        echo "Code: " . $error['code'] . "";
-        echo "Message: " . $error['message'] . "";
+        echo 'SQLSTATE: ' . $error['SQLSTATE'] . '';
+        echo 'Code: ' . $error['code'] . '';
+        echo 'Message: ' . $error['message'] . '';
     }
 }

--- a/samples/tutorials/php/Windows/SqlServerSample/crud.php
+++ b/samples/tutorials/php/Windows/SqlServerSample/crud.php
@@ -15,7 +15,8 @@ $params = ['Jake', 'United States'];
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults === false || $rowsAffected === false) {
-    die(format_errors(sqlsrv_errors()));
+    format_errors(sqlsrv_errors());
+    die();
 }
 echo($rowsAffected . ' row(s) inserted: ' . PHP_EOL);
 
@@ -31,7 +32,8 @@ echo('Updating Location for user ' . $userToUpdate . PHP_EOL);
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults === false || $rowsAffected === false) {
-    die(format_errors(sqlsrv_errors()));
+    format_errors(sqlsrv_errors());
+    die();
 }
 echo($rowsAffected . ' row(s) updated: ' . PHP_EOL);
 sqlsrv_free_stmt($getResults);
@@ -44,7 +46,8 @@ $getResults = sqlsrv_query($conn, $tsql, $params);
 echo('Deleting user ' . $userToDelete . PHP_EOL);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults === false || $rowsAffected === false) {
-    die(format_errors(sqlsrv_errors()));
+    format_errors(sqlsrv_errors());
+    die();
 }
 echo($rowsAffected . ' row(s) deleted: ' . PHP_EOL);
 sqlsrv_free_stmt($getResults);
@@ -54,7 +57,8 @@ $tsql = 'SELECT Id, Name, Location FROM TestSchema.Employees;';
 $getResults = sqlsrv_query($conn, $tsql);
 echo('Reading data from table' . PHP_EOL);
 if ($getResults === false) {
-    die(format_errors(sqlsrv_errors()));
+    format_errors(sqlsrv_errors());
+    die();
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
     echo($row['Id'] . ' ' . $row['Name'] . ' ' . $row['Location'] . PHP_EOL);

--- a/samples/tutorials/php/Windows/SqlServerSample/crud.php
+++ b/samples/tutorials/php/Windows/SqlServerSample/crud.php
@@ -1,74 +1,74 @@
 <?php
 $serverName = "localhost";
-$connectionOptions = array(
+$connectionOptions = [
     "Database" => "SampleDB",
     "Uid" => "sa",
-    "PWD" => "your_password"
-);
+    "PWD" => "your_password",
+];
 //Establishes the connection
 $conn = sqlsrv_connect($serverName, $connectionOptions);
 
 //Insert Query
-echo ("Inserting a new row into table" . PHP_EOL);
-$tsql= "INSERT INTO TestSchema.Employees (Name, Location) VALUES (?,?);";
-$params = array('Jake','United States');
-$getResults= sqlsrv_query($conn, $tsql, $params);
+echo("Inserting a new row into table" . PHP_EOL);
+$tsql = "INSERT INTO TestSchema.Employees (Name, Location) VALUES (?,?);";
+$params = ['Jake', 'United States'];
+$getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
-if ($getResults == FALSE or $rowsAffected == FALSE)
+if ($getResults == false or $rowsAffected == false) {
     die(FormatErrors(sqlsrv_errors()));
-echo ($rowsAffected. " row(s) inserted: " . PHP_EOL);
+}
+echo($rowsAffected . " row(s) inserted: " . PHP_EOL);
 
 sqlsrv_free_stmt($getResults);
 
 //Update Query
 
 $userToUpdate = 'Nikita';
-$tsql= "UPDATE TestSchema.Employees SET Location = ? WHERE Name = ?";
-$params = array('Sweeden', $userToUpdate);
+$tsql = "UPDATE TestSchema.Employees SET Location = ? WHERE Name = ?";
+$params = ['Sweeden', $userToUpdate];
 echo("Updating Location for user " . $userToUpdate . PHP_EOL);
 
-$getResults= sqlsrv_query($conn, $tsql, $params);
+$getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
-if ($getResults == FALSE or $rowsAffected == FALSE)
+if ($getResults == false or $rowsAffected == false) {
     die(FormatErrors(sqlsrv_errors()));
-echo ($rowsAffected. " row(s) updated: " . PHP_EOL);
+}
+echo($rowsAffected . " row(s) updated: " . PHP_EOL);
 sqlsrv_free_stmt($getResults);
 
 //Delete Query
 $userToDelete = 'Jared';
-$tsql= "DELETE FROM TestSchema.Employees WHERE Name = ?";
-$params = array($userToDelete);
-$getResults= sqlsrv_query($conn, $tsql, $params);
+$tsql = "DELETE FROM TestSchema.Employees WHERE Name = ?";
+$params = [$userToDelete];
+$getResults = sqlsrv_query($conn, $tsql, $params);
 echo("Deleting user " . $userToDelete . PHP_EOL);
 $rowsAffected = sqlsrv_rows_affected($getResults);
-if ($getResults == FALSE or $rowsAffected == FALSE)
+if ($getResults == false or $rowsAffected == false) {
     die(FormatErrors(sqlsrv_errors()));
-echo ($rowsAffected. " row(s) deleted: " . PHP_EOL);
+}
+echo($rowsAffected . " row(s) deleted: " . PHP_EOL);
 sqlsrv_free_stmt($getResults);
 
-
 //Read Query
-$tsql= "SELECT Id, Name, Location FROM TestSchema.Employees;";
-$getResults= sqlsrv_query($conn, $tsql);
-echo ("Reading data from table" . PHP_EOL);
-if ($getResults == FALSE)
+$tsql = "SELECT Id, Name, Location FROM TestSchema.Employees;";
+$getResults = sqlsrv_query($conn, $tsql);
+echo("Reading data from table" . PHP_EOL);
+if ($getResults == false) {
     die(FormatErrors(sqlsrv_errors()));
+}
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
-    echo ($row['Id'] . " " . $row['Name'] . " " . $row['Location'] . PHP_EOL);
-
+    echo($row['Id'] . " " . $row['Name'] . " " . $row['Location'] . PHP_EOL);
 }
 sqlsrv_free_stmt($getResults);
 
-function FormatErrors( $errors )
+function FormatErrors($errors)
 {
     /* Display errors. */
     echo "Error information: ";
 
-    foreach ( $errors as $error )
-    {
-        echo "SQLSTATE: ".$error['SQLSTATE']."";
-        echo "Code: ".$error['code']."";
-        echo "Message: ".$error['message']."";
+    foreach ($errors as $error) {
+        echo "SQLSTATE: " . $error['SQLSTATE'] . "";
+        echo "Code: " . $error['code'] . "";
+        echo "Message: " . $error['message'] . "";
     }
 }
-?>

--- a/samples/tutorials/php/Windows/SqlServerSample/crud.php
+++ b/samples/tutorials/php/Windows/SqlServerSample/crud.php
@@ -15,7 +15,7 @@ $params = ['Jake', 'United States'];
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults === false || $rowsAffected === false) {
-    die(formatErrors(sqlsrv_errors()));
+    die(format_errors(sqlsrv_errors()));
 }
 echo($rowsAffected . ' row(s) inserted: ' . PHP_EOL);
 
@@ -31,7 +31,7 @@ echo('Updating Location for user ' . $userToUpdate . PHP_EOL);
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults === false || $rowsAffected === false) {
-    die(formatErrors(sqlsrv_errors()));
+    die(format_errors(sqlsrv_errors()));
 }
 echo($rowsAffected . ' row(s) updated: ' . PHP_EOL);
 sqlsrv_free_stmt($getResults);
@@ -44,7 +44,7 @@ $getResults = sqlsrv_query($conn, $tsql, $params);
 echo('Deleting user ' . $userToDelete . PHP_EOL);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults === false || $rowsAffected === false) {
-    die(formatErrors(sqlsrv_errors()));
+    die(format_errors(sqlsrv_errors()));
 }
 echo($rowsAffected . ' row(s) deleted: ' . PHP_EOL);
 sqlsrv_free_stmt($getResults);
@@ -54,14 +54,14 @@ $tsql = 'SELECT Id, Name, Location FROM TestSchema.Employees;';
 $getResults = sqlsrv_query($conn, $tsql);
 echo('Reading data from table' . PHP_EOL);
 if ($getResults === false) {
-    die(formatErrors(sqlsrv_errors()));
+    die(format_errors(sqlsrv_errors()));
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
     echo($row['Id'] . ' ' . $row['Name'] . ' ' . $row['Location'] . PHP_EOL);
 }
 sqlsrv_free_stmt($getResults);
 
-function formatErrors($errors)
+function format_errors($errors)
 {
     /* Display errors. */
     echo 'Error information: ';

--- a/samples/tutorials/php/Windows/SqlServerSample/crud.php
+++ b/samples/tutorials/php/Windows/SqlServerSample/crud.php
@@ -14,7 +14,7 @@ $tsql = 'INSERT INTO TestSchema.Employees (Name, Location) VALUES (?,?);';
 $params = ['Jake', 'United States'];
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
-if ($getResults == false || $rowsAffected == false) {
+if ($getResults === false || $rowsAffected === false) {
     die(formatErrors(sqlsrv_errors()));
 }
 echo($rowsAffected . ' row(s) inserted: ' . PHP_EOL);
@@ -30,7 +30,7 @@ echo('Updating Location for user ' . $userToUpdate . PHP_EOL);
 
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
-if ($getResults == false || $rowsAffected == false) {
+if ($getResults === false || $rowsAffected === false) {
     die(formatErrors(sqlsrv_errors()));
 }
 echo($rowsAffected . ' row(s) updated: ' . PHP_EOL);
@@ -43,7 +43,7 @@ $params = [$userToDelete];
 $getResults = sqlsrv_query($conn, $tsql, $params);
 echo('Deleting user ' . $userToDelete . PHP_EOL);
 $rowsAffected = sqlsrv_rows_affected($getResults);
-if ($getResults == false || $rowsAffected == false) {
+if ($getResults === false || $rowsAffected === false) {
     die(formatErrors(sqlsrv_errors()));
 }
 echo($rowsAffected . ' row(s) deleted: ' . PHP_EOL);
@@ -53,7 +53,7 @@ sqlsrv_free_stmt($getResults);
 $tsql = 'SELECT Id, Name, Location FROM TestSchema.Employees;';
 $getResults = sqlsrv_query($conn, $tsql);
 echo('Reading data from table' . PHP_EOL);
-if ($getResults == false) {
+if ($getResults === false) {
     die(formatErrors(sqlsrv_errors()));
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {

--- a/samples/tutorials/php/Windows/SqlServerSample/crud.php
+++ b/samples/tutorials/php/Windows/SqlServerSample/crud.php
@@ -26,7 +26,7 @@ sqlsrv_free_stmt($getResults);
 
 $userToUpdate = 'Nikita';
 $tsql = 'UPDATE TestSchema.Employees SET Location = ? WHERE Name = ?';
-$params = ['Sweeden', $userToUpdate];
+$params = ['Sweden', $userToUpdate];
 echo('Updating Location for user ' . $userToUpdate . PHP_EOL);
 
 $getResults = sqlsrv_query($conn, $tsql, $params);

--- a/samples/tutorials/php/Windows/SqlServerSample/crud.php
+++ b/samples/tutorials/php/Windows/SqlServerSample/crud.php
@@ -5,10 +5,10 @@ $connectionOptions = [
     "Uid" => "sa",
     "PWD" => "your_password",
 ];
-//Establishes the connection
+// Establishes the connection
 $conn = sqlsrv_connect($serverName, $connectionOptions);
 
-//Insert Query
+// Insert Query
 echo("Inserting a new row into table" . PHP_EOL);
 $tsql = "INSERT INTO TestSchema.Employees (Name, Location) VALUES (?,?);";
 $params = ['Jake', 'United States'];
@@ -21,7 +21,7 @@ echo($rowsAffected . " row(s) inserted: " . PHP_EOL);
 
 sqlsrv_free_stmt($getResults);
 
-//Update Query
+// Update Query
 
 $userToUpdate = 'Nikita';
 $tsql = "UPDATE TestSchema.Employees SET Location = ? WHERE Name = ?";
@@ -36,7 +36,7 @@ if ($getResults == false || $rowsAffected == false) {
 echo($rowsAffected . " row(s) updated: " . PHP_EOL);
 sqlsrv_free_stmt($getResults);
 
-//Delete Query
+// Delete Query
 $userToDelete = 'Jared';
 $tsql = "DELETE FROM TestSchema.Employees WHERE Name = ?";
 $params = [$userToDelete];
@@ -49,7 +49,7 @@ if ($getResults == false || $rowsAffected == false) {
 echo($rowsAffected . " row(s) deleted: " . PHP_EOL);
 sqlsrv_free_stmt($getResults);
 
-//Read Query
+// Read Query
 $tsql = "SELECT Id, Name, Location FROM TestSchema.Employees;";
 $getResults = sqlsrv_query($conn, $tsql);
 echo("Reading data from table" . PHP_EOL);

--- a/samples/tutorials/php/Windows/SqlServerSample/crud.php
+++ b/samples/tutorials/php/Windows/SqlServerSample/crud.php
@@ -15,7 +15,7 @@ $params = ['Jake', 'United States'];
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults == false || $rowsAffected == false) {
-    die(FormatErrors(sqlsrv_errors()));
+    die(formatErrors(sqlsrv_errors()));
 }
 echo($rowsAffected . " row(s) inserted: " . PHP_EOL);
 
@@ -31,7 +31,7 @@ echo("Updating Location for user " . $userToUpdate . PHP_EOL);
 $getResults = sqlsrv_query($conn, $tsql, $params);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults == false || $rowsAffected == false) {
-    die(FormatErrors(sqlsrv_errors()));
+    die(formatErrors(sqlsrv_errors()));
 }
 echo($rowsAffected . " row(s) updated: " . PHP_EOL);
 sqlsrv_free_stmt($getResults);
@@ -44,7 +44,7 @@ $getResults = sqlsrv_query($conn, $tsql, $params);
 echo("Deleting user " . $userToDelete . PHP_EOL);
 $rowsAffected = sqlsrv_rows_affected($getResults);
 if ($getResults == false || $rowsAffected == false) {
-    die(FormatErrors(sqlsrv_errors()));
+    die(formatErrors(sqlsrv_errors()));
 }
 echo($rowsAffected . " row(s) deleted: " . PHP_EOL);
 sqlsrv_free_stmt($getResults);
@@ -54,14 +54,14 @@ $tsql = "SELECT Id, Name, Location FROM TestSchema.Employees;";
 $getResults = sqlsrv_query($conn, $tsql);
 echo("Reading data from table" . PHP_EOL);
 if ($getResults == false) {
-    die(FormatErrors(sqlsrv_errors()));
+    die(formatErrors(sqlsrv_errors()));
 }
 while ($row = sqlsrv_fetch_array($getResults, SQLSRV_FETCH_ASSOC)) {
     echo($row['Id'] . " " . $row['Name'] . " " . $row['Location'] . PHP_EOL);
 }
 sqlsrv_free_stmt($getResults);
 
-function FormatErrors($errors)
+function formatErrors($errors)
 {
     /* Display errors. */
     echo "Error information: ";


### PR DESCRIPTION
As discussed in https://github.com/microsoft/sql-server-samples/pull/763#issuecomment-618513361, this modernizes and cleans up the PHP examples.

I tried to improve it in small steps so the changes can be understood each by its own.

This also adds a [Composer](https://getcomposer.org/) file and adds the popular code style tool [PHPCS](https://github.com/squizlabs/PHP_CodeSniffer) as development dependency. This is _not_ necessary but would make it easier in the future to keep the examples clean and modern.

I also added a [PHPCS configuration/ruleset file](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-Ruleset) to setup the code style rules.

The  coding standard used is [PSR-2](https://www.php-fig.org/psr/psr-2/).

Lastly, an [.editorconfig](https://editorconfig.org/) file helps to configure IDEs that support it to format code accordingly.