### PR TITLE
Fix on image list

### DIFF
--- a/samples/features/sql-big-data-cluster/deployment/offline/push-bdc-images-to-custom-private-repo.py
+++ b/samples/features/sql-big-data-cluster/deployment/offline/push-bdc-images-to-custom-private-repo.py
@@ -27,29 +27,29 @@ TARGET_DOCKER_PASSWORD = getpass.getpass("Provide Docker password for the target
 TARGET_DOCKER_TAG = input("Provide Docker tag for the images at the target: ") or "latest"
 
 images = ['mssql-app-service-proxy',
-          'mssql-control-watchdog'
-           'mssql-controller'
-           'mssql-dns'
-           'mssql-hadoop'
-           'mssql-mleap-serving-runtime'
-           'mssql-mlserver-py-runtime'
-           'mssql-mlserver-r-runtime'
-           'mssql-monitor-collectd'
-           'mssql-monitor-elasticsearch'
-           'mssql-monitor-fluentbit'
-           'mssql-monitor-grafana'
-           'mssql-monitor-influxdb'
-           'mssql-monitor-kibana'
-           'mssql-monitor-telegraf'
-           'mssql-security-domainctl'
-           'mssql-security-knox'
-           'mssql-security-support'
-           'mssql-server'
-           'mssql-server-controller'
-           'mssql-server-data'
-           'mssql-ha-operator'
-           'mssql-ha-supervisor'
-           'mssql-service-proxy'
+          'mssql-control-watchdog',
+           'mssql-controller',
+           'mssql-dns',
+           'mssql-hadoop',
+           'mssql-mleap-serving-runtime',
+           'mssql-mlserver-py-runtime',
+           'mssql-mlserver-r-runtime',
+           'mssql-monitor-collectd',
+           'mssql-monitor-elasticsearch',
+           'mssql-monitor-fluentbit',
+           'mssql-monitor-grafana',
+           'mssql-monitor-influxdb',
+           'mssql-monitor-kibana',
+           'mssql-monitor-telegraf',
+           'mssql-security-domainctl',
+           'mssql-security-knox',
+           'mssql-security-support',
+           'mssql-server',
+           'mssql-server-controller',
+           'mssql-server-data',
+           'mssql-ha-operator',
+           'mssql-ha-supervisor',
+           'mssql-service-proxy',
            'mssql-ssis-app-runtime']
 
 # Use this only if your source is a private Docker registry


### PR DESCRIPTION
We are missing the comma between the image names causing an issue when we are trying to run the script. This create a wrong command that will be executed by the execute_cmd function.