### PR TITLE
Delete the output for parameterized notebook

### DIFF
--- a/samples/applications/azure-data-studio/parameterization.ipynb
+++ b/samples/applications/azure-data-studio/parameterization.ipynb
@@ -66,13 +66,7 @@
             "metadata": {
                 "azdata_cell_guid": "d3c849f6-fd01-467d-9240-1e8831b5d19f"
             },
-            "outputs": [
-                {
-                    "name": "stdout",
-                    "text": "Addition: 7.0\nMultiplication: 10.0\n",
-                    "output_type": "stream"
-                }
-            ],
+            "outputs": [],
             "execution_count": 3
         }
     ]


### PR DESCRIPTION
This is in order to use one consistent notebook for each of the parameterization methods. Allows for uri parameterization not to confuse the user when he loads the notebook with new parameters.