### PR TITLE
Deleting codes for removing servuce endpoints

### DIFF
--- a/samples/manage/azure-sql-db-managed-instance/prepare-subnet/prepareSubnet.ps1
+++ b/samples/manage/azure-sql-db-managed-instance/prepare-subnet/prepareSubnet.ps1
@@ -846,13 +846,6 @@ function VerifyRouteTable {
 }
 
 
-function PrepareServiceEndpoints
-{
-    param($subnet)
-    Write-Host "Removing service endpoints."
-    $subnet.ServiceEndpoints.Clear()
-}
-
 function PrepareServiceDelegation
 {
     param($subnet)

--- a/samples/manage/azure-sql-db-managed-instance/prepare-subnet/prepareSubnet.ps1
+++ b/samples/manage/azure-sql-db-managed-instance/prepare-subnet/prepareSubnet.ps1
@@ -1023,10 +1023,6 @@ If($isValid -ne $true)
 
     If ($applyChanges) 
     { 
-        If($isOkServiceEndpoints -ne $true)
-        {
-            PrepareServiceEndpoints $subnet
-        }
             
         If($isOkNSG -ne $true)
         {


### PR DESCRIPTION
The service endpoints are required for SQLMI to access storage account for adhoc backup /restore , replication , external tables etc. 
The code which I am asking to delete off is actually deleting such endpoints at the VNET when we run SQLMI deployer (update) again using this script as post script.