### PR TITLE
Update Spark sample code

### DIFF
--- a/samples/features/sql-big-data-cluster/spark/sparkml/train_score_export_ml_models_with_spark.ipynb
+++ b/samples/features/sql-big-data-cluster/spark/sparkml/train_score_export_ml_models_with_spark.ipynb
@@ -313,7 +313,7 @@
             "cell_type": "code",
             "source": [
                 "from pyspark.ml import Pipeline, PipelineModel\r\n",
-                "from pyspark.ml.feature import OneHotEncoderEstimator, StringIndexer, VectorAssembler\r\n",
+                "from pyspark.ml.feature import OneHotEncoder, StringIndexer, VectorAssembler\r\n",
                 "from pyspark.ml.classification import LogisticRegression\r\n",
                 "\r\n",
                 "reg = 0.1\r\n",
@@ -335,7 +335,7 @@
                 "        \r\n",
                 "        tmpCol = \"-\".join([key, \"tmp\"])\r\n",
                 "        si_xvars.append(StringIndexer(inputCol=key, outputCol=tmpCol, handleInvalid=\"skip\")) #, handleInvalid=\"keep\"\r\n",
-                "        ohe_xvars.append(OneHotEncoderEstimator(inputCols=[tmpCol], outputCols=[featureCol]))\r\n",
+                "        ohe_xvars.append(OneHotEncoder(inputCols=[tmpCol], outputCols=[featureCol]))\r\n",
                 "    else:\r\n",
                 "        featureCols.append(key)\r\n",
                 "\r\n",
@@ -378,7 +378,7 @@
                 },
                 {
                     "name": "stdout",
-                    "text": "Using LogisticRegression model with Regularization Rate of 0.1.\nPipeline Created\nModel Trained\nModel is  PipelineModel_dd10dea16fcc\nModel Stages [StringIndexer_a72809f2344f, OneHotEncoderEstimator_bff5847e2bae, StringIndexer_e62df3c26c82, VectorAssembler_e84f4c37608c, LogisticRegressionModel: uid = LogisticRegression_96385e6ff190, numClasses = 2, numFeatures = 17]",
+                    "text": "Using LogisticRegression model with Regularization Rate of 0.1.\nPipeline Created\nModel Trained\nModel is  PipelineModel_dd10dea16fcc\nModel Stages [StringIndexer_a72809f2344f, OneHotEncoder_bff5847e2bae, StringIndexer_e62df3c26c82, VectorAssembler_e84f4c37608c, LogisticRegressionModel: uid = LogisticRegression_96385e6ff190, numClasses = 2, numFeatures = 17]",
                     "output_type": "stream"
                 }
             ],


### PR DESCRIPTION
OneHotEncoder class name change.

Modified "sparkml/train_score_export_ml_models_with_spark.ipynb": updated class name.

Tested with SQL 2019 BDC CU15.

Signed-off-by: Renat Bekbolatov <rebekbol@microsoft.com>