### PR TITLE
Updating migration script for data-driven subscription PASSWORD field

### DIFF
--- a/samples/features/reporting-services/ssrs-migration-rss/ssrs_migration.rss
+++ b/samples/features/reporting-services/ssrs-migration-rss/ssrs_migration.rss
@@ -656,12 +656,34 @@ Sub MigrateReportSubscriptions(snkReport As CatalogItem, srcReport As CatalogIte
 				RsSrc.GetDataDrivenSubscriptionProperties(srcSub.SubscriptionID, extensionSettings, dataRetrievalPlan, description, active, status, eventType, matchData, parameters)				
 				If extensionSettings.Extension = "Report Server FileShare" Then
 					Dim newParameterValues() As [ParameterValueOrFieldReference] = New [ParameterValueOrFieldReference](extensionSettings.ParameterValues.Length) {}
-					Array.Copy(extensionSettings.ParameterValues, newParameterValues, extensionSettings.ParameterValues.Length)	
-					Dim pwdParameterValue As ParameterValue = New ParameterValue
-					pwdParameterValue.Label = "PASSWORD"
-					pwdParameterValue.Name = "PASSWORD"
-					pwdParameterValue.Value = "PASSWORD"
-					newParameterValues(extensionSettings.ParameterValues.Length) = pwdParameterValue
+					Dim passwordParamFound As Boolean = False
+					Array.Copy(extensionSettings.ParameterValues, newParameterValues, extensionSettings.ParameterValues.Length)
+					For Each pvofr As ParameterValueOrFieldReference In extensionSettings.ParameterValues
+						If TypeOf pvofr Is ParameterValue Then
+							Dim pv As ParameterValue = pvofr
+							If pv.Name.Contains("PASSWORD") Then
+								'Subscription has Password field linked to dataset field
+								passwordParamFound = True
+								Exit For
+							End If
+						Else If TypeOf pvofr Is ParameterFieldReference Then
+							Dim pfr As ParameterFieldReference = pvofr
+							If pfr.ParameterName.Contains("PASSWORD") Then
+								'Subscription has Password field linked to dataset field
+								passwordParamFound = True
+								Exit For
+							End If
+						End If
+					Next
+					If not passwordParamFound Then
+						'Subscription has Password field set to "Leave blank" or "Enter value"
+						Dim pwdParameterValue As ParameterValue = New ParameterValue
+						pwdParameterValue.Label = "PASSWORD"
+						pwdParameterValue.Name = "PASSWORD"
+						pwdParameterValue.Value = "PASSWORD"
+						newParameterValues(extensionSettings.ParameterValues.Length) = pwdParameterValue		
+					End If
+
 					extensionSettings.ParameterValues = newParameterValues					
 				End If
 						
@@ -688,7 +710,8 @@ Sub MigrateReportSubscriptions(snkReport As CatalogItem, srcReport As CatalogIte
 				RsSrc.GetSubscriptionProperties(srcSub.SubscriptionID, extensionSettings, description, active, status, eventType, matchData, parameters)
 				If extensionSettings.Extension = "Report Server FileShare" Then
 					Dim newParameterValues() As [ParameterValueOrFieldReference] = New [ParameterValueOrFieldReference](extensionSettings.ParameterValues.Length) {}
-					Array.Copy(extensionSettings.ParameterValues, newParameterValues, extensionSettings.ParameterValues.Length)	
+					Array.Copy(extensionSettings.ParameterValues, newParameterValues, extensionSettings.ParameterValues.Length)
+					'Standard subscriptions will always require adding PASSWORD parameter during migration
 					Dim pwdParameterValue As ParameterValue = New ParameterValue
 					pwdParameterValue.Label = "PASSWORD"
 					pwdParameterValue.Name = "PASSWORD"


### PR DESCRIPTION
CSS had a support ticket in which the customer had a password field provided by the data-driven subscription dataset query. The current GitHub script fails because it is trying to add a second instance of the PASSWORD parameter. The failure is:

Migrating data-driven subscription Monthly run of DATA0006116 (DataPortal) ... FAILURE:
System.Web.Services.Protocols.SoapException: An internal error occurred on the report server. See the error log for more details. ---> Microsoft.ReportingServices.Diagnostics.Utilities.InternalCatalogException: An internal error occurred on the report server. See the error log for more details. ---> System.ArgumentException: Item has already been added. Key in dictionary: 'PASSWORD'  Key being added: 'PASSWORD'
   at Microsoft.ReportingServices.Library.ReportingService2005Impl.CreateSubscription(String Report, ExtensionSettings ExtensionSettings 


The updated code will check if the PASSWORD parameter already exists. If it does, then it will not add the PASSWORD parameter. The customer tested the updated script code and it successfully migrated all of his RS content to the new RS server.