### PR TITLE
Fix crash of mssql_conf during setup with the MSSQL 2019 cu15

### DIFF
--- a/samples/features/high availability/Linux/Ansible Playbook/library/mssql_conf.py
+++ b/samples/features/high availability/Linux/Ansible Playbook/library/mssql_conf.py
@@ -125,9 +125,10 @@ def main():
 				changed = False
 		if need_to_set_up:
 			setup_env = os.environ.copy()
+			setup_env.update({ 'MSSQL_SA_PASSWORD': setup_sa_password, 'MSSQL_PID': setup_pid })
 			subprocess.check_call(
 				['/opt/mssql/bin/mssql-conf', '--noprompt', 'setup', 'accept-eula'],
-				env = { 'MSSQL_SA_PASSWORD': setup_sa_password, 'MSSQL_PID': setup_pid })
+				env = setup_env)
 
 	if name is not None:
 		subprocess.check_call(['/opt/mssql/bin/mssql-conf', '--noprompt', 'set', name, value])


### PR DESCRIPTION
Hello everybody,
In the CU15 (15.0.4198.2), the mssql-conf tool was rewrited. With this sqlserver's update and the old version of mssql_conf, we get an error "usermod command not found" during the checkinstance.sh's execution. This fix adds a merge operation of setup_env dictionary with the MSSQL_SA_PASSWORD and MSSQL_PID variables.

[ansible.log](https://github.com/microsoft/sql-server-samples/files/8262735/ansible.log)
A sample program to reproduce the problem.

```python
import subprocess
setup_sa_password='Azerty1!'
setup_pid='developer'
subprocess.check_call(
  ['/opt/mssql/bin/mssql-conf', '--noprompt', '-v', 'setup', 'accept-eula'],
  env = { 'MSSQL_SA_PASSWORD': setup_sa_password, 'MSSQL_PID': setup_pid })
```


[python_reproduce_error.log](https://github.com/microsoft/sql-server-samples/files/8262768/python_reproduce_error.log)

Regards.