### PR TITLE
nodejs/macos example:Add missing connect statement

### DIFF
--- a/samples/tutorials/node.js/macOS/SqlServerColumnstoreSample/columnstore.js
+++ b/samples/tutorials/node.js/macOS/SqlServerColumnstoreSample/columnstore.js
@@ -45,3 +45,6 @@ connection.on('connect', function(err) {
         },
     ]);
 });
+
+// Initialize the connection.
+connection.connect();

--- a/samples/tutorials/node.js/macOS/SqlServerSample/connect.js
+++ b/samples/tutorials/node.js/macOS/SqlServerSample/connect.js
@@ -21,3 +21,6 @@ connection.on('connect', function(err) {
     console.log('Connected');
   }
 });
+
+// Initialize the connection.
+connection.connect();

--- a/samples/tutorials/node.js/macOS/SqlServerSample/crud.js
+++ b/samples/tutorials/node.js/macOS/SqlServerSample/crud.js
@@ -123,7 +123,10 @@ connection.on('connect', function(err) {
       } else {
         console.log("Done!");
       }
-    }
-                   )
+    })
   }
 });
+
+
+// Initialize the connection.
+connection.connect();


### PR DESCRIPTION
This example is missing the `connection.connect();` line. This function is required to connect to the database. 

Reference: tediousjs documentation: http://tediousjs.github.io/tedious/api-connection.html