### PR TITLE
Fixed migration of reports with dot in name

### DIFF
--- a/samples/features/reporting-services/ssrs-migration-rss/ssrs_migration.rss
+++ b/samples/features/reporting-services/ssrs-migration-rss/ssrs_migration.rss
@@ -948,12 +948,12 @@ End Function
 
 'Helper function to construct correctly formatted filename
 Function GetSnkFilename(srcFilename As String, type As String) As String
-	Dim currentFE As String = GetFileNameExtension(srcFilename)
+	Dim currentFileExtension As String = GetFileNameExtension(srcFilename)
 
-	If SnkIsNative And (GetExtension(type) = currentFE) and currentFE <> "" Then 'Cut off file extension, if present
+	If SnkIsNative And (GetExtension(type) = currentFileExtension) and currentFileExtension <> "" Then 'Cut off file extension, if present
 		srcFilename = RemoveFileExtension(srcFilename)
 
-	ElseIf Not SnkIsNative And currentFE = "" Then 'Add file extension, if not present
+	ElseIf Not SnkIsNative And currentFileExtension = "" Then 'Add file extension, if not present
 		srcFilename = srcFilename + GetExtension(type)
 	End If
 

--- a/samples/features/reporting-services/ssrs-migration-rss/ssrs_migration.rss
+++ b/samples/features/reporting-services/ssrs-migration-rss/ssrs_migration.rss
@@ -948,11 +948,12 @@ End Function
 
 'Helper function to construct correctly formatted filename
 Function GetSnkFilename(srcFilename As String, type As String) As String
-	Dim hasFE As Boolean = HasFileExtension(srcFilename)
-	If SnkIsNative And hasFE And Not GetExtension(type) = "" Then 'Cut off file extension, if present            
+	Dim currentFE As String = GetFileNameExtension(srcFilename)
+
+	If SnkIsNative And (GetExtension(type) = currentFE) and currentFE <> "" Then 'Cut off file extension, if present
 		srcFilename = RemoveFileExtension(srcFilename)
 
-	ElseIf Not SnkIsNative And Not hasFE Then 'Add file extension, if not present
+	ElseIf Not SnkIsNative And currentFE = "" Then 'Add file extension, if not present
 		srcFilename = srcFilename + GetExtension(type)
 	End If
 
@@ -960,9 +961,14 @@ Function GetSnkFilename(srcFilename As String, type As String) As String
 End Function
 
 'Helper
-Function HasFileExtension(filename As String) As Boolean
-	Dim index As Integer = filename.LastIndexOf(".")
-	Return index >= 0 And filename.Length - index <= 5
+Function GetFileNameExtension(filename As String) As String
+	Dim index as Integer = -1
+	index = filename.LastIndexOf(".")
+	If index > 0
+		Return filename.Substring(index)
+	Else
+		Return ""
+	End If
 End Function
 
 'Helper


### PR DESCRIPTION
If user uses [script](https://github.com/Microsoft/sql-server-samples/tree/master/samples/features/reporting-services/ssrs-migration-rss) to migrate from ssrs12 to ssrs17 and the items which will be migrated have symbol "." in their name, then everything after the dot in the item's name will be truncated.

Also if parent reports have a dot in their name and part of the name gets truncated during migration then linked reports cannot be relinked because the parent report's name is changed during the migration.