### PR TITLE
Making the deployment script portable

### DIFF
--- a/samples/features/sql-clr/Curl/SqlClrCurl.tt
+++ b/samples/features/sql-clr/Curl/SqlClrCurl.tt
@@ -32,19 +32,18 @@ DROP ASSEMBLY IF EXISTS SqlClrCurl;
 GO
 
 
+DECLARE @assembly VARBINARY(MAX) = <#= "0x" + BitConverter.ToString(System.IO.File.ReadAllBytes(this.Host.ResolvePath("bin\\Release\\SqlClrCurl.dll"))).Replace("-","")  #>
 DECLARE @hash VARBINARY(64);
-SELECT @hash = HASHBYTES('SHA2_512', BulkColumn)
-FROM OPENROWSET(BULK '<#= this.Host.ResolvePath("bin\\Release\\SqlClrCurl.dll") #>', SINGLE_BLOB) AS assembly_content
+SELECT @hash = HASHBYTES('SHA2_512', @assembly)
 
-IF(@hash IS NOT NULL)
+IF(not exists (select * from sys.trusted_assemblies where hash = @hash))
 	EXEC sp_add_trusted_assembly @hash, N'SqlClrCurl'
 ELSE
-	PRINT 'Cannot create hash for assembly!'
-GO
+	print 'Hash already exists'
 
 --Create the assembly
 CREATE ASSEMBLY SqlClrCurl
-FROM '<#= this.Host.ResolvePath("bin\\Release\\SqlClrCurl.dll") #>'
+FROM @assembly
 WITH PERMISSION_SET = EXTERNAL_ACCESS;
 GO
 


### PR DESCRIPTION
Embedding the assembly bytes in the deployment script to make it portable, and support Managed Instance