### PR TITLE
Updated T4 template for SQL Script and misc fixes

### DIFF
--- a/samples/features/sql-clr/Curl/Curl.cs
+++ b/samples/features/sql-clr/Curl/Curl.cs
@@ -9,10 +9,16 @@ using System.Threading;
 /// </summary>
 public partial class Curl
 {
+    static Curl()
+    {
+        ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+    }
+
     [SqlFunction]
     [return: SqlFacet(MaxSize = -1)]
     public static SqlChars Get(SqlChars H, SqlChars url)
     {
+
         var client = new WebClient();
         AddHeader(H, client);
         return new SqlChars(
@@ -24,6 +30,7 @@ public partial class Curl
     [SqlProcedure]
     public static void Post(SqlChars H, SqlChars d, SqlChars url)
     {
+
         var client = new WebClient();
         AddHeader(H, client);
         if (d.IsNull)
@@ -39,6 +46,7 @@ public partial class Curl
     [SqlProcedure]
     public static void PostWithRetry(SqlChars H, SqlChars d, SqlChars url)
     {
+
         var client = new WebClient();
         AddHeader(H, client);
         if (d.IsNull)

--- a/samples/features/sql-clr/Curl/SqlClrCurl.csproj
+++ b/samples/features/sql-clr/Curl/SqlClrCurl.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SqlClr</RootNamespace>
     <AssemblyName>SqlClrCurl</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/samples/features/sql-clr/Curl/SqlClrCurl.tt
+++ b/samples/features/sql-clr/Curl/SqlClrCurl.tt
@@ -24,13 +24,13 @@ SELECT @hash = hash
 FROM sys.trusted_assemblies ta
 WHERE ta.description = N'SqlClrCurl'
 
-EXEC sp_drop_trusted_assembly @hash;
+if (@hash is not null)
+	EXEC sp_drop_trusted_assembly @hash;
 GO
 
 --Drop the assembly if it already exists
 DROP ASSEMBLY IF EXISTS SqlClrCurl;
 GO
-
 
 DECLARE @assembly VARBINARY(MAX) = <#= "0x" + BitConverter.ToString(System.IO.File.ReadAllBytes(this.Host.ResolvePath("bin\\Release\\SqlClrCurl.dll"))).Replace("-","")  #>
 DECLARE @hash VARBINARY(64);

--- a/samples/features/sql-clr/Curl/SqlClrCurl.tt
+++ b/samples/features/sql-clr/Curl/SqlClrCurl.tt
@@ -32,19 +32,18 @@ DROP ASSEMBLY IF EXISTS SqlClrCurl;
 GO
 
 
+DECLARE @assembly VARBINARY(MAX) = <#= "0x" + BitConverter.ToString(System.IO.File.ReadAllBytes(this.Host.ResolvePath("bin\\Release\\SqlClrCurl.dll"))).Replace("-","")  #>
 DECLARE @hash VARBINARY(64);
-SELECT @hash = HASHBYTES('SHA2_512', BulkColumn)
-FROM OPENROWSET(BULK '<#= this.Host.ResolvePath("bin\\Release\\SqlClrCurl.dll") #>', SINGLE_BLOB) AS assembly_content
+SELECT @hash = HASHBYTES('SHA2_512', @assembly)
 
-IF(@hash IS NOT NULL)
+IF(not exists (select * from sys.trusted_assemblies where hash = @hash))
 	EXEC sp_add_trusted_assembly @hash, N'SqlClrCurl'
 ELSE
-	PRINT 'Cannot create hash for assembly!'
-GO
+	print 'Hash already exists'
 
 --Create the assembly
 CREATE ASSEMBLY SqlClrCurl
-FROM '<#= this.Host.ResolvePath("bin\\Release\\SqlClrCurl.dll") #>'
+FROM @assembly
 WITH PERMISSION_SET = EXTERNAL_ACCESS;
 GO
 


### PR DESCRIPTION
1) Embedded the relase assemby in the SQL file as a hex string for portability

2) Dropped the existing trusted_assembly only if it exists, avoiding error.

3) Updated targeting to .NET Framework 4.7.1

4)  Forced TLS 1.2 in a static constructor to Curl.  Encryption will fail otherwise.  Looks like some back-compat behavior in SQLCLR was causing an old encryption suite to be used.