### PR TITLE
Fix Exponential growth in Daily simulation

### DIFF
--- a/samples/databases/wide-world-importers/wwi-ssdt/wwi-ssdt/DataLoadSimulation/Stored Procedures/DailyProcessToCreateHistory.sql
+++ b/samples/databases/wide-world-importers/wwi-ssdt/wwi-ssdt/DataLoadSimulation/Stored Procedures/DailyProcessToCreateHistory.sql
@@ -39,6 +39,7 @@ BEGIN
 		FROM (SELECT COUNT(*) AS OrderCount FROM Sales.Orders 
 			WHERE DATEPART(year,OrderDate) = DATEPART(year,(SELECT MAX(OrderDate) FROM Sales.Orders))
 				AND DATEPART(weekday,OrderDate) NOT IN (1,7)
+				AND BackorderOrderID IS NULL
 			GROUP BY OrderDate) t
 	END
 	ELSE


### PR DESCRIPTION
Repeated calls to this procedure cause exponential growth in orders. Including this condition fixes that.

During the data simulation process, there is a process to pick orders. If there is not enough stock to pick a full order, that order is split into an Original and Backordered Order. This could result in a chain of orders, with only the final one having a null value for the BackorderOrderID.