### PR TITLE
Update script

### DIFF
--- a/samples/manage/sql-assessment-api/RHEL/runassessment.ps1
+++ b/samples/manage/sql-assessment-api/RHEL/runassessment.ps1
@@ -96,7 +96,8 @@ try {
     $login, $pwd    = Get-Content '/var/opt/mssql/secrets/assessment' -Encoding UTF8NoBOM -TotalCount 2
     $securePassword = ConvertTo-SecureString $pwd -AsPlainText -Force
     $credential     = New-Object System.Management.Automation.PSCredential ($login, $securePassword)
-
+    $securePassword.MakeReadOnly()
+    
     Write-Verbose "Acquired credentials"
 
     $serverInstance = '.'
@@ -111,15 +112,15 @@ try {
         }
     }
 
-    $serverName = (Invoke-SqlCmd -ServerInstance $serverInstance -Credential $credential -Query "SELECT @@SERVERNAME")[0]
-    $hostName   = (Invoke-SqlCmd -ServerInstance $serverInstance -Credential $credential -Query "SELECT HOST_NAME()")[0]
+    $serverName = (Invoke-SqlCmd -ServerInstance $serverInstance -Credential $credential -Query "SELECT @@SERVERNAME" -TrustServerCertificate)[0]
+    $hostName   = (Invoke-SqlCmd -ServerInstance $serverInstance -Credential $credential -Query "SELECT HOST_NAME()" -TrustServerCertificate)[0]
 
     # Invoke assessment and store results.
     # Replace 'ConvertTo-Json' with 'ConvertTo-Csv' to change output format.
     # Available output formats: JSON, CSV, XML.
     # Encoding parameter is optional.
 
-    Get-SqlInstance -ServerInstance $serverInstance -Credential $credential -ErrorAction Stop
+    Get-SqlInstance -ServerInstance $serverInstance -Credential $credential -ErrorAction Stop -TrustServerCertificate
     | Get-TargetsRecursive
     | %{ Write-Verbose "Invoke assessment on $($_.Urn)"; $_ }
     | Invoke-SqlAssessment 3>&1
@@ -137,4 +138,4 @@ finally {
         | ConvertTo-Json -AsArray
         | Set-Content $errorPath -Encoding UTF8NoBOM
     }
-}
+}cd dev/

--- a/samples/manage/sql-assessment-api/RHEL/runassessment.ps1
+++ b/samples/manage/sql-assessment-api/RHEL/runassessment.ps1
@@ -138,4 +138,4 @@ finally {
         | ConvertTo-Json -AsArray
         | Set-Content $errorPath -Encoding UTF8NoBOM
     }
-}cd dev/
+}

--- a/samples/manage/sql-assessment-api/RHEL/runassessment.ps1
+++ b/samples/manage/sql-assessment-api/RHEL/runassessment.ps1
@@ -112,15 +112,16 @@ try {
         }
     }
 
-    $serverName = (Invoke-SqlCmd -ServerInstance $serverInstance -Credential $credential -Query "SELECT @@SERVERNAME" -TrustServerCertificate)[0]
-    $hostName   = (Invoke-SqlCmd -ServerInstance $serverInstance -Credential $credential -Query "SELECT HOST_NAME()" -TrustServerCertificate)[0]
+    # IMPORTANT: If the script is run in trusted environments and there is a prelogin handshake error, add -TrustServerCertificate flag in lines 116, 117 and 124 
+    $serverName = (Invoke-SqlCmd -ServerInstance $serverInstance -Credential $credential -Query "SELECT @@SERVERNAME")[0]
+    $hostName   = (Invoke-SqlCmd -ServerInstance $serverInstance -Credential $credential -Query "SELECT HOST_NAME()")[0]
 
     # Invoke assessment and store results.
     # Replace 'ConvertTo-Json' with 'ConvertTo-Csv' to change output format.
     # Available output formats: JSON, CSV, XML.
     # Encoding parameter is optional.
 
-    Get-SqlInstance -ServerInstance $serverInstance -Credential $credential -ErrorAction Stop -TrustServerCertificate
+    Get-SqlInstance -ServerInstance $serverInstance -Credential $credential -ErrorAction Stop
     | Get-TargetsRecursive
     | %{ Write-Verbose "Invoke assessment on $($_.Urn)"; $_ }
     | Invoke-SqlAssessment 3>&1


### PR DESCRIPTION
- Add -TrustServerCertificate to fix the following error: 
```
Line |
 115 |  … rverName = (Invoke-SqlCmd -ServerInstance $serverInstance -Credential …
     |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | A connection was successfully established with the server, but then an
     | error occurred during the pre-login handshake. (provider: TCP Provider,
     | error: 35 - An internal exception was caught)
Invoke-Sqlcmd: /opt/mssql/bin/runassessment.ps1:115
Line |
 115 |  … rverName = (Invoke-SqlCmd -ServerInstance $serverInstance -Credential …
     |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Incorrect syntax was encountered while parsing ''.
```
- Make password readonly
```
Get-SqlInstance: /opt/mssql/bin/runassessment.ps1:123
Line |
 123 |      Get-SqlInstance -ServerInstance $serverInstance -Credential $cred …
     |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | password must be marked as read only.
```
