### PR TITLE
fix(datasyncrunbook): remove leftover line part

### DIFF
--- a/samples/features/sql-data-sync/DataSyncLogPowerShellRunbook.ps1
+++ b/samples/features/sql-data-sync/DataSyncLogPowerShellRunbook.ps1
@@ -41,7 +41,7 @@ Disable-AzContextAutosave -Scope Process
 # Connect to Azure with system-assigned managed identity
 $AzureContext = (Connect-AzAccount -Identity).context
 # set and store context
-$AzureContext = Set-AzContext -SubscriptionName $AzureContext.Subscription -DefaultProfile $AzureContextficateThumbprint $servicePrincipalConnection.CertificateThumbprint
+$AzureContext = Set-AzContext -SubscriptionName $AzureContext.Subscription -DefaultProfile $AzureContext
 
 # Create the function to create the authorization signature
 Function Build-Signature ($customerId, $sharedKey, $date, $contentLength, $method, $contentType, $resource)


### PR DESCRIPTION
There is a leftover portion of the line from the old AzureRM version.
Found when attempting to use as is in Azure Automation Account's Test Pane. Throws an error `a positional parameter cannot be found that accepts $null` with no obvious details.