### PR TITLE
20231213 Handle PSEdition = Core in Update attachVPNGateway.ps1

### DIFF
--- a/samples/manage/azure-sql-db-managed-instance/attach-vpn-gateway/attachVPNGateway.ps1
+++ b/samples/manage/azure-sql-db-managed-instance/attach-vpn-gateway/attachVPNGateway.ps1
@@ -19,7 +19,7 @@ if ($clientCertificatePassword -eq '' -or ($null -eq $clientCertificatePassword)
 
 function VerifyPSVersion {
     Write-Host "Verifying PowerShell version."
-    if ($PSVersionTable.PSEdition -eq "Desktop") {
+    if ($PSVersionTable.PSEdition -eq "Desktop" -or $PSVersionTable.PSEdition -eq "Core" ) {
         if (($PSVersionTable.PSVersion.Major -ge 6) -or
             (($PSVersionTable.PSVersion.Major -eq 5) -and ($PSVersionTable.PSVersion.Minor -ge 1))) {
             Write-Host "PowerShell version verified." -ForegroundColor Green
@@ -219,7 +219,7 @@ function CreateCerificateOpenSsl() {
 
 function CreateCertificate() {
     Write-Host "Creating certificate."
-    if ($PSVersionTable.PSEdition -eq "Desktop") {
+    if ($PSVersionTable.PSEdition -eq "Desktop" -or $PSVersionTable.PSEdition -eq "Core" ) {
         return CreateCerificateWindows
     }
     else {


### PR DESCRIPTION
This powershell script is critical to https://learn.microsoft.com/en-us/azure/azure-sql/managed-instance/point-to-site-p2s-configure?view=azuresql#attach-a-vpn-gateway-to-a-virtual-network

Two issues to report in PS7

PS C:\Users\wiassaf> $PSVersionTable

Name                           Value
----                           -----
PSVersion                      7.3.10
PSEdition                      Core
GitCommitId                    7.3.10
OS                             Microsoft Windows 10.0.20348
Platform                       Win32NT
PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0…}
PSRemotingProtocolVersion      2.3
SerializationVersion           1.1.0.1
WSManStackVersion              3.0

1. Incorrectly tries to do the `ipsec` route in Windows PS7, which has PSEdition = `Core`. Adding `-or` logic. I have submitted a pull request to address PS7 Core.
2. Does not properly detect the correct subscription in some circumstances. I was getting this output:

```
Sign-in successful.
Selecting subscription 'd8392f63-30b0-4d4f-9ebb-xxxxxx'...
Subscription selected.
Loading virtual network 'vnet-sql-mi-subscriber' in resource group 'sqlmi-repl-rg'.
Virtual network vnet-sql-mi-subscriber cannot be found.
```

The subscription string after "Selecting subscription" was the correct and inteded subscription, and yet, it was not finding the virtual network. It was not dropping into the `Write-Host "Switching subscription ... ` block. To solve, outside of the cmdlet, I had to use `connect-azaccount` and `set-azsubscription` to set the correct subscription (to the correct and intended subscription that is not the first in my long list of subscriptions). Then, the cmdlet proceeded on. Unclear why this is happening, perhaps a cached version? Perhaps this cmdlet should manually force `connect-azaccount`.

