### PR TITLE
Added section: Servers with Errors communicating with Azure DPS Service

### DIFF
--- a/samples/features/azure-arc/dashboard/SQL Server Instances.json
+++ b/samples/features/azure-arc/dashboard/SQL Server Instances.json
@@ -741,6 +741,60 @@
                 "subtitle": ""
               }
             }
+          },
+          "14": {
+            "position": {
+              "x": 0,
+              "y": 30,
+              "colSpan": 19,
+              "rowSpan": 4
+            },
+            "metadata": {
+              "inputs": [
+                {
+                  "name": "partTitle",
+                  "value": "Query 1",
+                  "isOptional": true
+                },
+                {
+                  "name": "chartType",
+                  "isOptional": true
+                },
+                {
+                  "name": "isShared",
+                  "isOptional": true
+                },
+                {
+                  "name": "queryId",
+                  "isOptional": true
+                },
+                {
+                  "name": "formatResults",
+                  "isOptional": true
+                },
+                {
+                  "name": "queryScope",
+                  "value": {
+                    "scope": 0,
+                    "values": []
+                  },
+                  "isOptional": true
+                },
+                {
+                  "name": "query",
+                  "value": "resources\r\n    | where type =~ 'microsoft.hybridcompute/machines/extensions'\r\n    | where properties.type in ('WindowsAgent.SqlServer','LinuxAgent.SqlServer')\r\n    | parse id with * '/providers/Microsoft.HybridCompute/machines/' machineName '/extensions/' *\r\n    | parse properties with * 'uploadStatus : ' uploadStatus ';' *\r\n    | project uploadStatus, subscriptionId, resourceGroup, machineName\r\n    | where uploadStatus !in ('OK') //comment this out to see all upload stats\r\n    | order by uploadStatus desc",
+                  "isOptional": true
+                }
+              ],
+              "type": "Extension/HubsExtension/PartType/ArgQueryGridTile",
+              "settings": {
+                "content": {}
+              },
+              "partHeader": {
+                "title": "Servers with Errors communicating with Azure DPS Service",
+                "subtitle": "For more information see https://learn.microsoft.com/en-us/sql/sql-server/azure-arc/troubleshoot-telemetry-endpoint"
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
Added section "Servers with Errors communicating with Azure DPS Service" to show the server names where there is a DPS Error message. These should be addressed following suggestions in the link https://learn.microsoft.com/en-us/sql/sql-server/azure-arc/troubleshoot-telemetry-endpoint?view=sql-server-ver16 which is also in the subtitle of the dashboard item.