### PR TITLE
fix corrupted wide-world-importers SSIS package file: "DailyETLMain.dtsx"

### DIFF
--- a/samples/databases/wide-world-importers/wwi-ssis/wwi-ssis/DailyETLMain.dtsx
+++ b/samples/databases/wide-world-importers/wwi-ssis/wwi-ssis/DailyETLMain.dtsx
@@ -6829,4 +6829,6255 @@ WITH RESULT SETS
 WITH RESULT SETS
 (
     (
-        [WWI Stock Item ID] int,
+        [WWI Stock Item ID] int, 
+        [Stock Item] nvarchar(100), 
+        Color nvarchar(20), 
+        [Selling Package] nvarchar(50), 
+        [Buying Package] nvarchar(50), 
+        Brand nvarchar(50), 
+        Size nvarchar(20), 
+        [Lead Time Days] int, 
+        [Quantity Per Outer] int, 
+        [Is Chiller Stock] bit, 
+        Barcode nvarchar(50), 
+        [Tax Rate] decimal(18,3), 
+        [Unit Price] decimal(18,2), 
+        [Recommended Retail Price] decimal(18,2), 
+        [Typical Weight Per Unit] decimal(18,3), 
+        Photo varbinary(max), 
+        [Valid From] datetime2(7), 
+        [Valid To] datetime2(7)
+    )
+);</property>
+                    <property
+                      dataType="System.String"
+                      description="The variable that contains the SQL command to be executed."
+                      name="SqlCommandVariable"></property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the column code page to use when code page information is unavailable from the data source."
+                      name="DefaultCodePage">1252</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Forces the use of the DefaultCodePage property value when describing character data."
+                      name="AlwaysUseDefaultCodePage">false</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the mode used to access the database."
+                      name="AccessMode"
+                      typeConverter="AccessMode">2</property>
+                    <property
+                      dataType="System.String"
+                      description="The mappings between the parameters in the SQL command and variables."
+                      name="ParameterMapping">"@LastCutoff:Input",{60BD9010-4784-49A6-8FF2-340D7AB3B70D};"@NewCutoff:Input",{B96D08A3-EC4E-45C1-8E78-526920753C6B};</property>
+                  </properties>
+                  <connections>
+                    <connection
+                      refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Connections[OleDbConnection]"
+                      connectionManagerID="{E8464E14-D126-4B86-AFFB-295B0D3506F4}:external"
+                      connectionManagerRefId="Project.ConnectionManagers[WWI_Source_DB]"
+                      description="The OLE DB runtime connection used to access the database."
+                      name="OleDbConnection" />
+                  </connections>
+                  <outputs>
+                    <output
+                      refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output]"
+                      name="OLE DB Source Output">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Valid From]"
+                          dataType="dbTimeStamp2"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Valid From]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Valid From]"
+                          name="Valid From"
+                          scale="7"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Valid To]"
+                          dataType="dbTimeStamp2"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Valid To]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Valid To]"
+                          name="Valid To"
+                          scale="7"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[WWI Stock Item ID]"
+                          dataType="i4"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[WWI Stock Item ID]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[WWI Stock Item ID]"
+                          name="WWI Stock Item ID"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Stock Item]"
+                          dataType="wstr"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Stock Item]"
+                          length="100"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Stock Item]"
+                          name="Stock Item"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Color]"
+                          dataType="wstr"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Color]"
+                          length="20"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Color]"
+                          name="Color"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Selling Package]"
+                          dataType="wstr"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Selling Package]"
+                          length="50"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Selling Package]"
+                          name="Selling Package"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Buying Package]"
+                          dataType="wstr"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Buying Package]"
+                          length="50"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Buying Package]"
+                          name="Buying Package"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Brand]"
+                          dataType="wstr"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Brand]"
+                          length="50"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Brand]"
+                          name="Brand"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Size]"
+                          dataType="wstr"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Size]"
+                          length="20"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Size]"
+                          name="Size"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Lead Time Days]"
+                          dataType="i4"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Lead Time Days]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Lead Time Days]"
+                          name="Lead Time Days"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Quantity Per Outer]"
+                          dataType="i4"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Quantity Per Outer]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Quantity Per Outer]"
+                          name="Quantity Per Outer"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Is Chiller Stock]"
+                          dataType="bool"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Is Chiller Stock]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Is Chiller Stock]"
+                          name="Is Chiller Stock"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Barcode]"
+                          dataType="wstr"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Barcode]"
+                          length="50"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Barcode]"
+                          name="Barcode"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Tax Rate]"
+                          dataType="numeric"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Tax Rate]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Tax Rate]"
+                          name="Tax Rate"
+                          precision="18"
+                          scale="3"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Unit Price]"
+                          dataType="numeric"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Unit Price]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Unit Price]"
+                          name="Unit Price"
+                          precision="18"
+                          scale="2"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Recommended Retail Price]"
+                          dataType="numeric"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Recommended Retail Price]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Recommended Retail Price]"
+                          name="Recommended Retail Price"
+                          precision="18"
+                          scale="2"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Typical Weight Per Unit]"
+                          dataType="numeric"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Typical Weight Per Unit]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Typical Weight Per Unit]"
+                          name="Typical Weight Per Unit"
+                          precision="18"
+                          scale="3"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Photo]"
+                          dataType="image"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Photo]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Photo]"
+                          name="Photo"
+                          truncationRowDisposition="FailComponent" />
+                      </outputColumns>
+                      <externalMetadataColumns
+                        isUsed="True">
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Valid From]"
+                          dataType="dbTimeStamp2"
+                          name="Valid From"
+                          scale="7" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Valid To]"
+                          dataType="dbTimeStamp2"
+                          name="Valid To"
+                          scale="7" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[WWI Stock Item ID]"
+                          dataType="i4"
+                          name="WWI Stock Item ID" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Stock Item]"
+                          dataType="wstr"
+                          length="100"
+                          name="Stock Item" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Color]"
+                          dataType="wstr"
+                          length="20"
+                          name="Color" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Selling Package]"
+                          dataType="wstr"
+                          length="50"
+                          name="Selling Package" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Buying Package]"
+                          dataType="wstr"
+                          length="50"
+                          name="Buying Package" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Brand]"
+                          dataType="wstr"
+                          length="50"
+                          name="Brand" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Size]"
+                          dataType="wstr"
+                          length="20"
+                          name="Size" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Lead Time Days]"
+                          dataType="i4"
+                          name="Lead Time Days" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Quantity Per Outer]"
+                          dataType="i4"
+                          name="Quantity Per Outer" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Is Chiller Stock]"
+                          dataType="bool"
+                          name="Is Chiller Stock" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Barcode]"
+                          dataType="wstr"
+                          length="50"
+                          name="Barcode" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Tax Rate]"
+                          dataType="numeric"
+                          name="Tax Rate"
+                          precision="18"
+                          scale="3" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Unit Price]"
+                          dataType="numeric"
+                          name="Unit Price"
+                          precision="18"
+                          scale="2" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Recommended Retail Price]"
+                          dataType="numeric"
+                          name="Recommended Retail Price"
+                          precision="18"
+                          scale="2" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Typical Weight Per Unit]"
+                          dataType="numeric"
+                          name="Typical Weight Per Unit"
+                          precision="18"
+                          scale="3" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].ExternalColumns[Photo]"
+                          dataType="image"
+                          name="Photo" />
+                      </externalMetadataColumns>
+                    </output>
+                    <output
+                      refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output]"
+                      isErrorOut="true"
+                      name="OLE DB Source Error Output">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[WWI Stock Item ID]"
+                          dataType="i4"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[WWI Stock Item ID]"
+                          name="WWI Stock Item ID" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Stock Item]"
+                          dataType="wstr"
+                          length="100"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Stock Item]"
+                          name="Stock Item" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Color]"
+                          dataType="wstr"
+                          length="20"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Color]"
+                          name="Color" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Selling Package]"
+                          dataType="wstr"
+                          length="50"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Selling Package]"
+                          name="Selling Package" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Buying Package]"
+                          dataType="wstr"
+                          length="50"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Buying Package]"
+                          name="Buying Package" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Brand]"
+                          dataType="wstr"
+                          length="50"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Brand]"
+                          name="Brand" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Size]"
+                          dataType="wstr"
+                          length="20"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Size]"
+                          name="Size" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Lead Time Days]"
+                          dataType="i4"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Lead Time Days]"
+                          name="Lead Time Days" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Quantity Per Outer]"
+                          dataType="i4"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Quantity Per Outer]"
+                          name="Quantity Per Outer" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Is Chiller Stock]"
+                          dataType="bool"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Is Chiller Stock]"
+                          name="Is Chiller Stock" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Barcode]"
+                          dataType="wstr"
+                          length="50"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Barcode]"
+                          name="Barcode" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Tax Rate]"
+                          dataType="numeric"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Tax Rate]"
+                          name="Tax Rate"
+                          precision="18"
+                          scale="3" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Unit Price]"
+                          dataType="numeric"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Unit Price]"
+                          name="Unit Price"
+                          precision="18"
+                          scale="2" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Recommended Retail Price]"
+                          dataType="numeric"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Recommended Retail Price]"
+                          name="Recommended Retail Price"
+                          precision="18"
+                          scale="2" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Typical Weight Per Unit]"
+                          dataType="numeric"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Typical Weight Per Unit]"
+                          name="Typical Weight Per Unit"
+                          precision="18"
+                          scale="3" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Photo]"
+                          dataType="image"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Photo]"
+                          name="Photo" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Valid From]"
+                          dataType="dbTimeStamp2"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Valid From]"
+                          name="Valid From"
+                          scale="7" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Valid To]"
+                          dataType="dbTimeStamp2"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[Valid To]"
+                          name="Valid To"
+                          scale="7" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                          dataType="i4"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                          name="ErrorCode"
+                          specialFlags="1" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                          dataType="i4"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                          name="ErrorColumn"
+                          specialFlags="2" />
+                      </outputColumns>
+                      <externalMetadataColumns />
+                    </output>
+                  </outputs>
+                </component>
+                <component
+                  refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging"
+                  componentClassID="Microsoft.OLEDBDestination"
+                  contactInfo="OLE DB Destination;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;4"
+                  description="OLE DB Destination"
+                  name="Integration_StockItem_Staging"
+                  usesDispositions="true"
+                  version="4">
+                  <properties>
+                    <property
+                      dataType="System.Int32"
+                      description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                      name="CommandTimeout">0</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the name of the database object used to open a rowset."
+                      name="OpenRowset">[Integration].[StockItem_Staging]</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the variable that contains the name of the database object used to open a rowset."
+                      name="OpenRowsetVariable"></property>
+                    <property
+                      dataType="System.String"
+                      description="The SQL command to be executed."
+                      name="SqlCommand"
+                      UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=16.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91"></property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the column code page to use when code page information is unavailable from the data source."
+                      name="DefaultCodePage">1252</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Forces the use of the DefaultCodePage property value when describing character data."
+                      name="AlwaysUseDefaultCodePage">false</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the mode used to access the database."
+                      name="AccessMode"
+                      typeConverter="AccessMode">3</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Indicates whether the values supplied for identity columns will be copied to the destination. If false, values for identity columns will be auto-generated at the destination. Applies only if fast load is turned on."
+                      name="FastLoadKeepIdentity">false</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Indicates whether the columns containing null will have null inserted in the destination. If false, columns containing null will have their default values inserted at the destination. Applies only if fast load is turned on."
+                      name="FastLoadKeepNulls">false</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies options to be used with fast load.  Applies only if fast load is turned on."
+                      name="FastLoadOptions">CHECK_CONSTRAINTS</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies when commits are issued during data insertion.  A value of 0 specifies that one commit will be issued at the end of data insertion.  Applies only if fast load is turned on."
+                      name="FastLoadMaxInsertCommitSize">2147483647</property>
+                  </properties>
+                  <connections>
+                    <connection
+                      refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Connections[OleDbConnection]"
+                      connectionManagerID="{7C3E3ECC-C5AD-4675-9618-FC08465F8BC9}:external"
+                      connectionManagerRefId="Project.ConnectionManagers[WWI_DW_Destination_DB]"
+                      description="The OLE DB runtime connection used to access the database."
+                      name="OleDbConnection" />
+                  </connections>
+                  <inputs>
+                    <input
+                      refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input]"
+                      errorOrTruncationOperation="Insert"
+                      errorRowDisposition="FailComponent"
+                      hasSideEffects="true"
+                      name="OLE DB Destination Input">
+                      <inputColumns>
+                        <inputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].Columns[Valid From]"
+                          cachedDataType="dbTimeStamp2"
+                          cachedName="Valid From"
+                          cachedScale="7"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Valid From]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Valid From]" />
+                        <inputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].Columns[Valid To]"
+                          cachedDataType="dbTimeStamp2"
+                          cachedName="Valid To"
+                          cachedScale="7"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Valid To]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Valid To]" />
+                        <inputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].Columns[WWI Stock Item ID]"
+                          cachedDataType="i4"
+                          cachedName="WWI Stock Item ID"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[WWI Stock Item ID]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[WWI Stock Item ID]" />
+                        <inputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].Columns[Stock Item]"
+                          cachedDataType="wstr"
+                          cachedLength="100"
+                          cachedName="Stock Item"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Stock Item]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Stock Item]" />
+                        <inputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].Columns[Color]"
+                          cachedDataType="wstr"
+                          cachedLength="20"
+                          cachedName="Color"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Color]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Color]" />
+                        <inputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].Columns[Selling Package]"
+                          cachedDataType="wstr"
+                          cachedLength="50"
+                          cachedName="Selling Package"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Selling Package]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Selling Package]" />
+                        <inputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].Columns[Buying Package]"
+                          cachedDataType="wstr"
+                          cachedLength="50"
+                          cachedName="Buying Package"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Buying Package]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Buying Package]" />
+                        <inputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].Columns[Brand]"
+                          cachedDataType="wstr"
+                          cachedLength="50"
+                          cachedName="Brand"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Brand]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Brand]" />
+                        <inputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].Columns[Size]"
+                          cachedDataType="wstr"
+                          cachedLength="20"
+                          cachedName="Size"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Size]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Size]" />
+                        <inputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].Columns[Lead Time Days]"
+                          cachedDataType="i4"
+                          cachedName="Lead Time Days"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Lead Time Days]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Lead Time Days]" />
+                        <inputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].Columns[Quantity Per Outer]"
+                          cachedDataType="i4"
+                          cachedName="Quantity Per Outer"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Quantity Per Outer]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Quantity Per Outer]" />
+                        <inputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].Columns[Is Chiller Stock]"
+                          cachedDataType="bool"
+                          cachedName="Is Chiller Stock"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Is Chiller Stock]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Is Chiller Stock]" />
+                        <inputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].Columns[Barcode]"
+                          cachedDataType="wstr"
+                          cachedLength="50"
+                          cachedName="Barcode"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Barcode]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Barcode]" />
+                        <inputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].Columns[Tax Rate]"
+                          cachedDataType="numeric"
+                          cachedName="Tax Rate"
+                          cachedPrecision="18"
+                          cachedScale="3"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Tax Rate]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Tax Rate]" />
+                        <inputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].Columns[Unit Price]"
+                          cachedDataType="numeric"
+                          cachedName="Unit Price"
+                          cachedPrecision="18"
+                          cachedScale="2"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Unit Price]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Unit Price]" />
+                        <inputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].Columns[Recommended Retail Price]"
+                          cachedDataType="numeric"
+                          cachedName="Recommended Retail Price"
+                          cachedPrecision="18"
+                          cachedScale="2"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Recommended Retail Price]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Recommended Retail Price]" />
+                        <inputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].Columns[Typical Weight Per Unit]"
+                          cachedDataType="numeric"
+                          cachedName="Typical Weight Per Unit"
+                          cachedPrecision="18"
+                          cachedScale="3"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Typical Weight Per Unit]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Typical Weight Per Unit]" />
+                        <inputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].Columns[Photo]"
+                          cachedDataType="image"
+                          cachedName="Photo"
+                          externalMetadataColumnId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Photo]"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output].Columns[Photo]" />
+                      </inputColumns>
+                      <externalMetadataColumns
+                        isUsed="True">
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Valid From]"
+                          dataType="dbTimeStamp2"
+                          name="Valid From"
+                          scale="7" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Valid To]"
+                          dataType="dbTimeStamp2"
+                          name="Valid To"
+                          scale="7" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Stock Item Staging Key]"
+                          dataType="i4"
+                          name="Stock Item Staging Key" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[WWI Stock Item ID]"
+                          dataType="i4"
+                          name="WWI Stock Item ID" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Stock Item]"
+                          dataType="wstr"
+                          length="100"
+                          name="Stock Item" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Color]"
+                          dataType="wstr"
+                          length="20"
+                          name="Color" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Selling Package]"
+                          dataType="wstr"
+                          length="50"
+                          name="Selling Package" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Buying Package]"
+                          dataType="wstr"
+                          length="50"
+                          name="Buying Package" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Brand]"
+                          dataType="wstr"
+                          length="50"
+                          name="Brand" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Size]"
+                          dataType="wstr"
+                          length="20"
+                          name="Size" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Lead Time Days]"
+                          dataType="i4"
+                          name="Lead Time Days" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Quantity Per Outer]"
+                          dataType="i4"
+                          name="Quantity Per Outer" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Is Chiller Stock]"
+                          dataType="bool"
+                          name="Is Chiller Stock" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Barcode]"
+                          dataType="wstr"
+                          length="50"
+                          name="Barcode" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Tax Rate]"
+                          dataType="numeric"
+                          name="Tax Rate"
+                          precision="18"
+                          scale="3" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Unit Price]"
+                          dataType="numeric"
+                          name="Unit Price"
+                          precision="18"
+                          scale="2" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Recommended Retail Price]"
+                          dataType="numeric"
+                          name="Recommended Retail Price"
+                          precision="18"
+                          scale="2" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Typical Weight Per Unit]"
+                          dataType="numeric"
+                          name="Typical Weight Per Unit"
+                          precision="18"
+                          scale="3" />
+                        <externalMetadataColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Photo]"
+                          dataType="image"
+                          name="Photo" />
+                      </externalMetadataColumns>
+                    </input>
+                  </inputs>
+                  <outputs>
+                    <output
+                      refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Outputs[OLE DB Destination Error Output]"
+                      exclusionGroup="1"
+                      isErrorOut="true"
+                      name="OLE DB Destination Error Output"
+                      synchronousInputId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input]">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                          dataType="i4"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                          name="ErrorCode"
+                          specialFlags="1" />
+                        <outputColumn
+                          refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                          dataType="i4"
+                          lineageId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                          name="ErrorColumn"
+                          specialFlags="2" />
+                      </outputColumns>
+                      <externalMetadataColumns />
+                    </output>
+                  </outputs>
+                </component>
+              </components>
+              <paths>
+                <path
+                  refId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging.Paths[OLE DB Source Output]"
+                  endId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging.Inputs[OLE DB Destination Input]"
+                  name="OLE DB Source Output"
+                  startId="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates.Outputs[OLE DB Source Output]" />
+              </paths>
+            </pipeline>
+          </DTS:ObjectData>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Load Stock Item Dimension\Get Last Stock Item ETL Cutoff Time"
+          DTS:CreationName="Microsoft.ExecuteSQLTask"
+          DTS:Description="Execute SQL Task"
+          DTS:DTSID="{102e6b70-e049-40ee-a0e7-5aa96067dc7e}"
+          DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Get Last Stock Item ETL Cutoff Time"
+          DTS:TaskContact="Execute SQL Task; Microsoft Corporation; SQL Server 2016 RC2; © 2015 Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1"
+          DTS:ThreadHint="0">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <SQLTask:SqlTaskData
+              SQLTask:Connection="{7C3E3ECC-C5AD-4675-9618-FC08465F8BC9}"
+              SQLTask:SqlStatementSource="EXEC Integration.GetLastETLCutoffTime ?;"
+              SQLTask:ResultType="ResultSetType_SingleRow" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask">
+              <SQLTask:ResultBinding
+                SQLTask:ResultName="CutoffTime"
+                SQLTask:DtsVariableName="User::LastETLCutoffTime" />
+              <SQLTask:ParameterBinding
+                SQLTask:ParameterName="0"
+                SQLTask:DtsVariableName="User::TableName"
+                SQLTask:ParameterDirection="Input"
+                SQLTask:DataType="130"
+                SQLTask:ParameterSize="-1" />
+            </SQLTask:SqlTaskData>
+          </DTS:ObjectData>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Load Stock Item Dimension\Get Lineage Key"
+          DTS:CreationName="Microsoft.ExecuteSQLTask"
+          DTS:Description="Execute SQL Task"
+          DTS:DTSID="{e2390b93-d1e5-4022-b8e9-e605bbbcc4a5}"
+          DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Get Lineage Key"
+          DTS:TaskContact="Execute SQL Task; Microsoft Corporation; SQL Server 2016 RC2; © 2015 Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1"
+          DTS:ThreadHint="0">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <SQLTask:SqlTaskData
+              SQLTask:Connection="{7C3E3ECC-C5AD-4675-9618-FC08465F8BC9}"
+              SQLTask:SqlStatementSource="EXEC Integration.GetLineageKey ?, ?;"
+              SQLTask:ResultType="ResultSetType_SingleRow" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask">
+              <SQLTask:ResultBinding
+                SQLTask:ResultName="LineageKey"
+                SQLTask:DtsVariableName="User::LineageKey" />
+              <SQLTask:ParameterBinding
+                SQLTask:ParameterName="0"
+                SQLTask:DtsVariableName="User::TableName"
+                SQLTask:ParameterDirection="Input"
+                SQLTask:DataType="130"
+                SQLTask:ParameterSize="-1" />
+              <SQLTask:ParameterBinding
+                SQLTask:ParameterName="1"
+                SQLTask:DtsVariableName="User::TargetETLCutoffTime"
+                SQLTask:ParameterDirection="Input"
+                SQLTask:DataType="7"
+                SQLTask:ParameterSize="-1" />
+            </SQLTask:SqlTaskData>
+          </DTS:ObjectData>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Load Stock Item Dimension\Migrate Staged Stock Item Data"
+          DTS:CreationName="Microsoft.ExecuteSQLTask"
+          DTS:Description="Execute SQL Task"
+          DTS:DTSID="{d9b80d84-bf87-450a-a963-a7c61643193f}"
+          DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Migrate Staged Stock Item Data"
+          DTS:TaskContact="Execute SQL Task; Microsoft Corporation; SQL Server 2016 RC2; © 2015 Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1"
+          DTS:ThreadHint="0">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <SQLTask:SqlTaskData
+              SQLTask:Connection="{7C3E3ECC-C5AD-4675-9618-FC08465F8BC9}"
+              SQLTask:SqlStatementSource="EXEC Integration.MigrateStagedStockItemData;" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask" />
+          </DTS:ObjectData>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Load Stock Item Dimension\Set TableName to Stock Item"
+          DTS:CreationName="Microsoft.ExpressionTask"
+          DTS:Description="Expression Task"
+          DTS:DTSID="{c3f2cc5c-4312-4fa2-8d0a-e0fc85c06ca4}"
+          DTS:ExecutableType="Microsoft.ExpressionTask"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Set TableName to Stock Item"
+          DTS:TaskContact="Expression Task;Microsoft Corporation; SQL Server 2016 RC2; © 2015 Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1"
+          DTS:ThreadHint="0">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <ExpressionTask
+              Expression="@[User::TableName] = &quot;Stock Item&quot;" />
+          </DTS:ObjectData>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Load Stock Item Dimension\Truncate StockItem_Staging"
+          DTS:CreationName="Microsoft.ExecuteSQLTask"
+          DTS:Description="Execute SQL Task"
+          DTS:DTSID="{2d0737a6-0d2b-46fe-8018-49f3ba7ace89}"
+          DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Truncate StockItem_Staging"
+          DTS:TaskContact="Execute SQL Task; Microsoft Corporation; SQL Server 2016 RC2; © 2015 Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1"
+          DTS:ThreadHint="0">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <SQLTask:SqlTaskData
+              SQLTask:Connection="{7C3E3ECC-C5AD-4675-9618-FC08465F8BC9}"
+              SQLTask:SqlStatementSource="DELETE FROM Integration.StockItem_Staging;" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask" />
+          </DTS:ObjectData>
+        </DTS:Executable>
+      </DTS:Executables>
+      <DTS:PrecedenceConstraints>
+        <DTS:PrecedenceConstraint
+          DTS:refId="Package\Load Stock Item Dimension.PrecedenceConstraints[Constraint]"
+          DTS:CreationName=""
+          DTS:DTSID="{79364a11-b415-474c-857e-2b1973e92aa8}"
+          DTS:From="Package\Load Stock Item Dimension\Set TableName to Stock Item"
+          DTS:LogicalAnd="True"
+          DTS:ObjectName="Constraint"
+          DTS:To="Package\Load Stock Item Dimension\Get Lineage Key" />
+        <DTS:PrecedenceConstraint
+          DTS:refId="Package\Load Stock Item Dimension.PrecedenceConstraints[Constraint 1]"
+          DTS:CreationName=""
+          DTS:DTSID="{29e5e01d-646f-420e-b54d-389c229fc66d}"
+          DTS:From="Package\Load Stock Item Dimension\Get Lineage Key"
+          DTS:LogicalAnd="True"
+          DTS:ObjectName="Constraint 1"
+          DTS:To="Package\Load Stock Item Dimension\Truncate StockItem_Staging" />
+        <DTS:PrecedenceConstraint
+          DTS:refId="Package\Load Stock Item Dimension.PrecedenceConstraints[Constraint 2]"
+          DTS:CreationName=""
+          DTS:DTSID="{2e169a8c-cfe4-46e0-a411-bae61c6666b1}"
+          DTS:From="Package\Load Stock Item Dimension\Truncate StockItem_Staging"
+          DTS:LogicalAnd="True"
+          DTS:ObjectName="Constraint 2"
+          DTS:To="Package\Load Stock Item Dimension\Get Last Stock Item ETL Cutoff Time" />
+        <DTS:PrecedenceConstraint
+          DTS:refId="Package\Load Stock Item Dimension.PrecedenceConstraints[Constraint 3]"
+          DTS:CreationName=""
+          DTS:DTSID="{7d18c09f-466c-4d4e-ad16-614c677b9fd0}"
+          DTS:From="Package\Load Stock Item Dimension\Get Last Stock Item ETL Cutoff Time"
+          DTS:LogicalAnd="True"
+          DTS:ObjectName="Constraint 3"
+          DTS:To="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging" />
+        <DTS:PrecedenceConstraint
+          DTS:refId="Package\Load Stock Item Dimension.PrecedenceConstraints[Constraint 4]"
+          DTS:CreationName=""
+          DTS:DTSID="{a7833c65-7130-4f05-8aa7-1ac2d153870f}"
+          DTS:From="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging"
+          DTS:LogicalAnd="True"
+          DTS:ObjectName="Constraint 4"
+          DTS:To="Package\Load Stock Item Dimension\Migrate Staged Stock Item Data" />
+      </DTS:PrecedenceConstraints>
+    </DTS:Executable>
+    <DTS:Executable
+      DTS:refId="Package\Load Supplier Dimension"
+      DTS:CreationName="STOCK:SEQUENCE"
+      DTS:Description="Sequence Container"
+      DTS:DTSID="{AAFC80AB-8064-43FD-AB8C-ACEA8C476A8E}"
+      DTS:ExecutableType="STOCK:SEQUENCE"
+      DTS:LocaleID="-1"
+      DTS:ObjectName="Load Supplier Dimension">
+      <DTS:Variables />
+      <DTS:Executables>
+        <DTS:Executable
+          DTS:refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging"
+          DTS:CreationName="Microsoft.Pipeline"
+          DTS:Description="Data Flow Task"
+          DTS:DTSID="{d8b6bc33-f2f6-492a-840f-b19f481167df}"
+          DTS:ExecutableType="Microsoft.Pipeline"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Extract Updated Supplier Data to Staging"
+          DTS:TaskContact="Performs high-performance data extraction, transformation and loading;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <pipeline
+              version="1">
+              <components>
+                <component
+                  refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates"
+                  componentClassID="Microsoft.OLEDBSource"
+                  contactInfo="OLE DB Source;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;7"
+                  description="OLE DB Source"
+                  name="Integration_GetSupplierUpdates"
+                  usesDispositions="true"
+                  version="7">
+                  <properties>
+                    <property
+                      dataType="System.Int32"
+                      description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                      name="CommandTimeout">0</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the name of the database object used to open a rowset."
+                      name="OpenRowset"></property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the variable that contains the name of the database object used to open a rowset."
+                      name="OpenRowsetVariable"></property>
+                    <property
+                      dataType="System.String"
+                      description="The SQL command to be executed."
+                      name="SqlCommand"
+                      UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=16.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91">EXEC Integration.GetSupplierUpdates ?, ?
+WITH RESULT SETS
+(
+    (
+        [WWI Supplier ID] int,
+        Supplier nvarchar(100),
+        Category nvarchar(50),
+        [Primary Contact] nvarchar(50),
+        [Supplier Reference] nvarchar(20),
+        [Payment Days] int,
+        [Postal Code] nvarchar(10),
+        [Valid From] datetime2(7),
+        [Valid To] datetime2(7)
+    )
+);</property>
+                    <property
+                      dataType="System.String"
+                      description="The variable that contains the SQL command to be executed."
+                      name="SqlCommandVariable"></property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the column code page to use when code page information is unavailable from the data source."
+                      name="DefaultCodePage">1252</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Forces the use of the DefaultCodePage property value when describing character data."
+                      name="AlwaysUseDefaultCodePage">false</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the mode used to access the database."
+                      name="AccessMode"
+                      typeConverter="AccessMode">2</property>
+                    <property
+                      dataType="System.String"
+                      description="The mappings between the parameters in the SQL command and variables."
+                      name="ParameterMapping">"@LastCutoff:Input",{60BD9010-4784-49A6-8FF2-340D7AB3B70D};"@NewCutoff:Input",{B96D08A3-EC4E-45C1-8E78-526920753C6B};</property>
+                  </properties>
+                  <connections>
+                    <connection
+                      refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Connections[OleDbConnection]"
+                      connectionManagerID="{E8464E14-D126-4B86-AFFB-295B0D3506F4}:external"
+                      connectionManagerRefId="Project.ConnectionManagers[WWI_Source_DB]"
+                      description="The OLE DB runtime connection used to access the database."
+                      name="OleDbConnection" />
+                  </connections>
+                  <outputs>
+                    <output
+                      refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output]"
+                      name="OLE DB Source Output">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].Columns[Valid From]"
+                          dataType="dbTimeStamp2"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].ExternalColumns[Valid From]"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].Columns[Valid From]"
+                          name="Valid From"
+                          scale="7"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].Columns[Valid To]"
+                          dataType="dbTimeStamp2"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].ExternalColumns[Valid To]"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].Columns[Valid To]"
+                          name="Valid To"
+                          scale="7"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].Columns[WWI Supplier ID]"
+                          dataType="i4"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].ExternalColumns[WWI Supplier ID]"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].Columns[WWI Supplier ID]"
+                          name="WWI Supplier ID"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].Columns[Supplier]"
+                          dataType="wstr"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].ExternalColumns[Supplier]"
+                          length="100"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].Columns[Supplier]"
+                          name="Supplier"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].Columns[Category]"
+                          dataType="wstr"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].ExternalColumns[Category]"
+                          length="50"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].Columns[Category]"
+                          name="Category"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].Columns[Primary Contact]"
+                          dataType="wstr"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].ExternalColumns[Primary Contact]"
+                          length="50"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].Columns[Primary Contact]"
+                          name="Primary Contact"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].Columns[Supplier Reference]"
+                          dataType="wstr"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].ExternalColumns[Supplier Reference]"
+                          length="20"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].Columns[Supplier Reference]"
+                          name="Supplier Reference"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].Columns[Payment Days]"
+                          dataType="i4"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].ExternalColumns[Payment Days]"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].Columns[Payment Days]"
+                          name="Payment Days"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].Columns[Postal Code]"
+                          dataType="wstr"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].ExternalColumns[Postal Code]"
+                          length="10"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].Columns[Postal Code]"
+                          name="Postal Code"
+                          truncationRowDisposition="FailComponent" />
+                      </outputColumns>
+                      <externalMetadataColumns
+                        isUsed="True">
+                        <externalMetadataColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].ExternalColumns[Valid From]"
+                          dataType="dbTimeStamp2"
+                          name="Valid From"
+                          scale="7" />
+                        <externalMetadataColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].ExternalColumns[Valid To]"
+                          dataType="dbTimeStamp2"
+                          name="Valid To"
+                          scale="7" />
+                        <externalMetadataColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].ExternalColumns[WWI Supplier ID]"
+                          dataType="i4"
+                          name="WWI Supplier ID" />
+                        <externalMetadataColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].ExternalColumns[Supplier]"
+                          dataType="wstr"
+                          length="100"
+                          name="Supplier" />
+                        <externalMetadataColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].ExternalColumns[Category]"
+                          dataType="wstr"
+                          length="50"
+                          name="Category" />
+                        <externalMetadataColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].ExternalColumns[Primary Contact]"
+                          dataType="wstr"
+                          length="50"
+                          name="Primary Contact" />
+                        <externalMetadataColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].ExternalColumns[Supplier Reference]"
+                          dataType="wstr"
+                          length="20"
+                          name="Supplier Reference" />
+                        <externalMetadataColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].ExternalColumns[Payment Days]"
+                          dataType="i4"
+                          name="Payment Days" />
+                        <externalMetadataColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].ExternalColumns[Postal Code]"
+                          dataType="wstr"
+                          length="10"
+                          name="Postal Code" />
+                      </externalMetadataColumns>
+                    </output>
+                    <output
+                      refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Error Output]"
+                      isErrorOut="true"
+                      name="OLE DB Source Error Output">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Error Output].Columns[WWI Supplier ID]"
+                          dataType="i4"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Error Output].Columns[WWI Supplier ID]"
+                          name="WWI Supplier ID" />
+                        <outputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Error Output].Columns[Supplier]"
+                          dataType="wstr"
+                          length="100"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Error Output].Columns[Supplier]"
+                          name="Supplier" />
+                        <outputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Error Output].Columns[Category]"
+                          dataType="wstr"
+                          length="50"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Error Output].Columns[Category]"
+                          name="Category" />
+                        <outputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Error Output].Columns[Primary Contact]"
+                          dataType="wstr"
+                          length="50"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Error Output].Columns[Primary Contact]"
+                          name="Primary Contact" />
+                        <outputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Error Output].Columns[Supplier Reference]"
+                          dataType="wstr"
+                          length="20"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Error Output].Columns[Supplier Reference]"
+                          name="Supplier Reference" />
+                        <outputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Error Output].Columns[Payment Days]"
+                          dataType="i4"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Error Output].Columns[Payment Days]"
+                          name="Payment Days" />
+                        <outputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Error Output].Columns[Postal Code]"
+                          dataType="wstr"
+                          length="10"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Error Output].Columns[Postal Code]"
+                          name="Postal Code" />
+                        <outputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Error Output].Columns[Valid From]"
+                          dataType="dbTimeStamp2"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Error Output].Columns[Valid From]"
+                          name="Valid From"
+                          scale="7" />
+                        <outputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Error Output].Columns[Valid To]"
+                          dataType="dbTimeStamp2"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Error Output].Columns[Valid To]"
+                          name="Valid To"
+                          scale="7" />
+                        <outputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                          dataType="i4"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                          name="ErrorCode"
+                          specialFlags="1" />
+                        <outputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                          dataType="i4"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                          name="ErrorColumn"
+                          specialFlags="2" />
+                      </outputColumns>
+                      <externalMetadataColumns />
+                    </output>
+                  </outputs>
+                </component>
+                <component
+                  refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging"
+                  componentClassID="Microsoft.OLEDBDestination"
+                  contactInfo="OLE DB Destination;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;4"
+                  description="OLE DB Destination"
+                  name="Integration_Supplier_Staging"
+                  usesDispositions="true"
+                  version="4">
+                  <properties>
+                    <property
+                      dataType="System.Int32"
+                      description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                      name="CommandTimeout">0</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the name of the database object used to open a rowset."
+                      name="OpenRowset">[Integration].[Supplier_Staging]</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the variable that contains the name of the database object used to open a rowset."
+                      name="OpenRowsetVariable"></property>
+                    <property
+                      dataType="System.String"
+                      description="The SQL command to be executed."
+                      name="SqlCommand"
+                      UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=16.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91"></property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the column code page to use when code page information is unavailable from the data source."
+                      name="DefaultCodePage">1252</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Forces the use of the DefaultCodePage property value when describing character data."
+                      name="AlwaysUseDefaultCodePage">false</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the mode used to access the database."
+                      name="AccessMode"
+                      typeConverter="AccessMode">3</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Indicates whether the values supplied for identity columns will be copied to the destination. If false, values for identity columns will be auto-generated at the destination. Applies only if fast load is turned on."
+                      name="FastLoadKeepIdentity">false</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Indicates whether the columns containing null will have null inserted in the destination. If false, columns containing null will have their default values inserted at the destination. Applies only if fast load is turned on."
+                      name="FastLoadKeepNulls">false</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies options to be used with fast load.  Applies only if fast load is turned on."
+                      name="FastLoadOptions">CHECK_CONSTRAINTS</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies when commits are issued during data insertion.  A value of 0 specifies that one commit will be issued at the end of data insertion.  Applies only if fast load is turned on."
+                      name="FastLoadMaxInsertCommitSize">2147483647</property>
+                  </properties>
+                  <connections>
+                    <connection
+                      refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Connections[OleDbConnection]"
+                      connectionManagerID="{7C3E3ECC-C5AD-4675-9618-FC08465F8BC9}:external"
+                      connectionManagerRefId="Project.ConnectionManagers[WWI_DW_Destination_DB]"
+                      description="The OLE DB runtime connection used to access the database."
+                      name="OleDbConnection" />
+                  </connections>
+                  <inputs>
+                    <input
+                      refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input]"
+                      errorOrTruncationOperation="Insert"
+                      errorRowDisposition="FailComponent"
+                      hasSideEffects="true"
+                      name="OLE DB Destination Input">
+                      <inputColumns>
+                        <inputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input].Columns[Valid From]"
+                          cachedDataType="dbTimeStamp2"
+                          cachedName="Valid From"
+                          cachedScale="7"
+                          externalMetadataColumnId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Valid From]"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].Columns[Valid From]" />
+                        <inputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input].Columns[Valid To]"
+                          cachedDataType="dbTimeStamp2"
+                          cachedName="Valid To"
+                          cachedScale="7"
+                          externalMetadataColumnId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Valid To]"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].Columns[Valid To]" />
+                        <inputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input].Columns[WWI Supplier ID]"
+                          cachedDataType="i4"
+                          cachedName="WWI Supplier ID"
+                          externalMetadataColumnId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input].ExternalColumns[WWI Supplier ID]"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].Columns[WWI Supplier ID]" />
+                        <inputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input].Columns[Supplier]"
+                          cachedDataType="wstr"
+                          cachedLength="100"
+                          cachedName="Supplier"
+                          externalMetadataColumnId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Supplier]"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].Columns[Supplier]" />
+                        <inputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input].Columns[Category]"
+                          cachedDataType="wstr"
+                          cachedLength="50"
+                          cachedName="Category"
+                          externalMetadataColumnId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Category]"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].Columns[Category]" />
+                        <inputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input].Columns[Primary Contact]"
+                          cachedDataType="wstr"
+                          cachedLength="50"
+                          cachedName="Primary Contact"
+                          externalMetadataColumnId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Primary Contact]"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].Columns[Primary Contact]" />
+                        <inputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input].Columns[Supplier Reference]"
+                          cachedDataType="wstr"
+                          cachedLength="20"
+                          cachedName="Supplier Reference"
+                          externalMetadataColumnId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Supplier Reference]"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].Columns[Supplier Reference]" />
+                        <inputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input].Columns[Payment Days]"
+                          cachedDataType="i4"
+                          cachedName="Payment Days"
+                          externalMetadataColumnId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Payment Days]"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].Columns[Payment Days]" />
+                        <inputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input].Columns[Postal Code]"
+                          cachedDataType="wstr"
+                          cachedLength="10"
+                          cachedName="Postal Code"
+                          externalMetadataColumnId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Postal Code]"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output].Columns[Postal Code]" />
+                      </inputColumns>
+                      <externalMetadataColumns
+                        isUsed="True">
+                        <externalMetadataColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Valid From]"
+                          dataType="dbTimeStamp2"
+                          name="Valid From"
+                          scale="7" />
+                        <externalMetadataColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Valid To]"
+                          dataType="dbTimeStamp2"
+                          name="Valid To"
+                          scale="7" />
+                        <externalMetadataColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Supplier Staging Key]"
+                          dataType="i4"
+                          name="Supplier Staging Key" />
+                        <externalMetadataColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input].ExternalColumns[WWI Supplier ID]"
+                          dataType="i4"
+                          name="WWI Supplier ID" />
+                        <externalMetadataColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Supplier]"
+                          dataType="wstr"
+                          length="100"
+                          name="Supplier" />
+                        <externalMetadataColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Category]"
+                          dataType="wstr"
+                          length="50"
+                          name="Category" />
+                        <externalMetadataColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Primary Contact]"
+                          dataType="wstr"
+                          length="50"
+                          name="Primary Contact" />
+                        <externalMetadataColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Supplier Reference]"
+                          dataType="wstr"
+                          length="20"
+                          name="Supplier Reference" />
+                        <externalMetadataColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Payment Days]"
+                          dataType="i4"
+                          name="Payment Days" />
+                        <externalMetadataColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Postal Code]"
+                          dataType="wstr"
+                          length="10"
+                          name="Postal Code" />
+                      </externalMetadataColumns>
+                    </input>
+                  </inputs>
+                  <outputs>
+                    <output
+                      refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Outputs[OLE DB Destination Error Output]"
+                      exclusionGroup="1"
+                      isErrorOut="true"
+                      name="OLE DB Destination Error Output"
+                      synchronousInputId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input]">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                          dataType="i4"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                          name="ErrorCode"
+                          specialFlags="1" />
+                        <outputColumn
+                          refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                          dataType="i4"
+                          lineageId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                          name="ErrorColumn"
+                          specialFlags="2" />
+                      </outputColumns>
+                      <externalMetadataColumns />
+                    </output>
+                  </outputs>
+                </component>
+              </components>
+              <paths>
+                <path
+                  refId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging.Paths[OLE DB Source Output]"
+                  endId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging.Inputs[OLE DB Destination Input]"
+                  name="OLE DB Source Output"
+                  startId="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates.Outputs[OLE DB Source Output]" />
+              </paths>
+            </pipeline>
+          </DTS:ObjectData>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Load Supplier Dimension\Get Last Supplier ETL Cutoff Time"
+          DTS:CreationName="Microsoft.ExecuteSQLTask"
+          DTS:Description="Execute SQL Task"
+          DTS:DTSID="{32b928a2-282f-40c3-ac24-b021e9ed8ced}"
+          DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Get Last Supplier ETL Cutoff Time"
+          DTS:TaskContact="Execute SQL Task; Microsoft Corporation; SQL Server 2016 RC2; © 2015 Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1"
+          DTS:ThreadHint="0">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <SQLTask:SqlTaskData
+              SQLTask:Connection="{7C3E3ECC-C5AD-4675-9618-FC08465F8BC9}"
+              SQLTask:SqlStatementSource="EXEC Integration.GetLastETLCutoffTime ?;"
+              SQLTask:ResultType="ResultSetType_SingleRow" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask">
+              <SQLTask:ResultBinding
+                SQLTask:ResultName="CutoffTime"
+                SQLTask:DtsVariableName="User::LastETLCutoffTime" />
+              <SQLTask:ParameterBinding
+                SQLTask:ParameterName="0"
+                SQLTask:DtsVariableName="User::TableName"
+                SQLTask:ParameterDirection="Input"
+                SQLTask:DataType="130"
+                SQLTask:ParameterSize="-1" />
+            </SQLTask:SqlTaskData>
+          </DTS:ObjectData>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Load Supplier Dimension\Get Lineage Key"
+          DTS:CreationName="Microsoft.ExecuteSQLTask"
+          DTS:Description="Execute SQL Task"
+          DTS:DTSID="{1aaa4132-cd12-4679-8464-b6eb1d64258e}"
+          DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Get Lineage Key"
+          DTS:TaskContact="Execute SQL Task; Microsoft Corporation; SQL Server 2016 RC2; © 2015 Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1"
+          DTS:ThreadHint="0">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <SQLTask:SqlTaskData
+              SQLTask:Connection="{7C3E3ECC-C5AD-4675-9618-FC08465F8BC9}"
+              SQLTask:SqlStatementSource="EXEC Integration.GetLineageKey ?, ?;"
+              SQLTask:ResultType="ResultSetType_SingleRow" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask">
+              <SQLTask:ResultBinding
+                SQLTask:ResultName="LineageKey"
+                SQLTask:DtsVariableName="User::LineageKey" />
+              <SQLTask:ParameterBinding
+                SQLTask:ParameterName="0"
+                SQLTask:DtsVariableName="User::TableName"
+                SQLTask:ParameterDirection="Input"
+                SQLTask:DataType="130"
+                SQLTask:ParameterSize="-1" />
+              <SQLTask:ParameterBinding
+                SQLTask:ParameterName="1"
+                SQLTask:DtsVariableName="User::TargetETLCutoffTime"
+                SQLTask:ParameterDirection="Input"
+                SQLTask:DataType="7"
+                SQLTask:ParameterSize="-1" />
+            </SQLTask:SqlTaskData>
+          </DTS:ObjectData>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Load Supplier Dimension\Migrate Staged Supplier Data"
+          DTS:CreationName="Microsoft.ExecuteSQLTask"
+          DTS:Description="Execute SQL Task"
+          DTS:DTSID="{824af9ca-7654-4af2-a842-7114622f2a9b}"
+          DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Migrate Staged Supplier Data"
+          DTS:TaskContact="Execute SQL Task; Microsoft Corporation; SQL Server 2016 RC2; © 2015 Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1"
+          DTS:ThreadHint="0">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <SQLTask:SqlTaskData
+              SQLTask:Connection="{7C3E3ECC-C5AD-4675-9618-FC08465F8BC9}"
+              SQLTask:SqlStatementSource="EXEC Integration.MigrateStagedSupplierData;" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask" />
+          </DTS:ObjectData>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Load Supplier Dimension\Set TableName to Supplier"
+          DTS:CreationName="Microsoft.ExpressionTask"
+          DTS:Description="Expression Task"
+          DTS:DTSID="{18312baf-e712-446c-ac0f-36465f639a66}"
+          DTS:ExecutableType="Microsoft.ExpressionTask"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Set TableName to Supplier"
+          DTS:TaskContact="Expression Task;Microsoft Corporation; SQL Server 2016 RC2; © 2015 Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1"
+          DTS:ThreadHint="0">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <ExpressionTask
+              Expression="@[User::TableName] = &quot;Supplier&quot;" />
+          </DTS:ObjectData>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Load Supplier Dimension\Truncate Supplier_Staging"
+          DTS:CreationName="Microsoft.ExecuteSQLTask"
+          DTS:Description="Execute SQL Task"
+          DTS:DTSID="{ec520610-1378-40a4-bec0-526cd47566a8}"
+          DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Truncate Supplier_Staging"
+          DTS:TaskContact="Execute SQL Task; Microsoft Corporation; SQL Server 2016 RC2; © 2015 Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1"
+          DTS:ThreadHint="0">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <SQLTask:SqlTaskData
+              SQLTask:Connection="{7C3E3ECC-C5AD-4675-9618-FC08465F8BC9}"
+              SQLTask:SqlStatementSource="DELETE FROM Integration.Supplier_Staging;" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask" />
+          </DTS:ObjectData>
+        </DTS:Executable>
+      </DTS:Executables>
+      <DTS:PrecedenceConstraints>
+        <DTS:PrecedenceConstraint
+          DTS:refId="Package\Load Supplier Dimension.PrecedenceConstraints[Constraint]"
+          DTS:CreationName=""
+          DTS:DTSID="{432618e1-e15c-414f-86dd-6e2eeeba80b9}"
+          DTS:From="Package\Load Supplier Dimension\Set TableName to Supplier"
+          DTS:LogicalAnd="True"
+          DTS:ObjectName="Constraint"
+          DTS:To="Package\Load Supplier Dimension\Get Lineage Key" />
+        <DTS:PrecedenceConstraint
+          DTS:refId="Package\Load Supplier Dimension.PrecedenceConstraints[Constraint 1]"
+          DTS:CreationName=""
+          DTS:DTSID="{361f60e5-6164-492e-9426-dee24e858a17}"
+          DTS:From="Package\Load Supplier Dimension\Get Lineage Key"
+          DTS:LogicalAnd="True"
+          DTS:ObjectName="Constraint 1"
+          DTS:To="Package\Load Supplier Dimension\Truncate Supplier_Staging" />
+        <DTS:PrecedenceConstraint
+          DTS:refId="Package\Load Supplier Dimension.PrecedenceConstraints[Constraint 2]"
+          DTS:CreationName=""
+          DTS:DTSID="{2dc4dfee-381d-413a-a7fb-71daa303e8e5}"
+          DTS:From="Package\Load Supplier Dimension\Truncate Supplier_Staging"
+          DTS:LogicalAnd="True"
+          DTS:ObjectName="Constraint 2"
+          DTS:To="Package\Load Supplier Dimension\Get Last Supplier ETL Cutoff Time" />
+        <DTS:PrecedenceConstraint
+          DTS:refId="Package\Load Supplier Dimension.PrecedenceConstraints[Constraint 3]"
+          DTS:CreationName=""
+          DTS:DTSID="{7c77ec5b-22c2-431a-b555-67bb0b6dbbe4}"
+          DTS:From="Package\Load Supplier Dimension\Get Last Supplier ETL Cutoff Time"
+          DTS:LogicalAnd="True"
+          DTS:ObjectName="Constraint 3"
+          DTS:To="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging" />
+        <DTS:PrecedenceConstraint
+          DTS:refId="Package\Load Supplier Dimension.PrecedenceConstraints[Constraint 4]"
+          DTS:CreationName=""
+          DTS:DTSID="{3d4e4a98-37da-4b22-ba2e-97c4183d65c3}"
+          DTS:From="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging"
+          DTS:LogicalAnd="True"
+          DTS:ObjectName="Constraint 4"
+          DTS:To="Package\Load Supplier Dimension\Migrate Staged Supplier Data" />
+      </DTS:PrecedenceConstraints>
+    </DTS:Executable>
+    <DTS:Executable
+      DTS:refId="Package\Load Transaction Fact"
+      DTS:CreationName="STOCK:SEQUENCE"
+      DTS:Description="Sequence Container"
+      DTS:DTSID="{0D2109DF-68E7-4F1C-AC76-5FAF9781B864}"
+      DTS:ExecutableType="STOCK:SEQUENCE"
+      DTS:LocaleID="-1"
+      DTS:ObjectName="Load Transaction Fact">
+      <DTS:Variables />
+      <DTS:Executables>
+        <DTS:Executable
+          DTS:refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging"
+          DTS:CreationName="Microsoft.Pipeline"
+          DTS:Description="Data Flow Task"
+          DTS:DTSID="{a599201a-9c89-4318-98d1-fc3ceed2e5b0}"
+          DTS:ExecutableType="Microsoft.Pipeline"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Extract Updated Transaction Data to Staging"
+          DTS:TaskContact="Performs high-performance data extraction, transformation and loading;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <pipeline
+              version="1">
+              <components>
+                <component
+                  refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates"
+                  componentClassID="Microsoft.OLEDBSource"
+                  contactInfo="OLE DB Source;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;7"
+                  description="OLE DB Source"
+                  name="Integration_GetTransactionUpdates"
+                  usesDispositions="true"
+                  version="7">
+                  <properties>
+                    <property
+                      dataType="System.Int32"
+                      description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                      name="CommandTimeout">0</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the name of the database object used to open a rowset."
+                      name="OpenRowset"></property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the variable that contains the name of the database object used to open a rowset."
+                      name="OpenRowsetVariable"></property>
+                    <property
+                      dataType="System.String"
+                      description="The SQL command to be executed."
+                      name="SqlCommand"
+                      UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=16.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91">EXEC Integration.GetTransactionUpdates ?, ?
+WITH RESULT SETS
+(
+    (
+        [Date Key] date,
+        [WWI Customer Transaction ID] int,
+        [WWI Supplier Transaction ID] int,
+        [WWI Invoice ID] int,
+        [WWI Purchase Order ID] int,
+        [Supplier Invoice Number] nvarchar(20),
+        [Total Excluding Tax] decimal(18,2),
+        [Tax Amount] decimal(18,2),
+        [Total Including Tax] decimal(18,2),
+        [Outstanding Balance] decimal(18,2),
+        [Is Finalized] bit,
+        [WWI Customer ID] int,
+        [WWI Bill To Customer ID] int,
+        [WWI Supplier ID] int,
+        [WWI Transaction Type ID] int,
+        [WWI Payment Method ID] int,
+        [Last Modified When] datetime2(7)
+    )
+);</property>
+                    <property
+                      dataType="System.String"
+                      description="The variable that contains the SQL command to be executed."
+                      name="SqlCommandVariable"></property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the column code page to use when code page information is unavailable from the data source."
+                      name="DefaultCodePage">1252</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Forces the use of the DefaultCodePage property value when describing character data."
+                      name="AlwaysUseDefaultCodePage">false</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the mode used to access the database."
+                      name="AccessMode"
+                      typeConverter="AccessMode">2</property>
+                    <property
+                      dataType="System.String"
+                      description="The mappings between the parameters in the SQL command and variables."
+                      name="ParameterMapping">"@LastCutoff:Input",{60BD9010-4784-49A6-8FF2-340D7AB3B70D};"@NewCutoff:Input",{B96D08A3-EC4E-45C1-8E78-526920753C6B};</property>
+                  </properties>
+                  <connections>
+                    <connection
+                      refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Connections[OleDbConnection]"
+                      connectionManagerID="{E8464E14-D126-4B86-AFFB-295B0D3506F4}:external"
+                      connectionManagerRefId="Project.ConnectionManagers[WWI_Source_DB]"
+                      description="The OLE DB runtime connection used to access the database."
+                      name="OleDbConnection" />
+                  </connections>
+                  <outputs>
+                    <output
+                      refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output]"
+                      name="OLE DB Source Output">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[Last Modified When]"
+                          dataType="dbTimeStamp2"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[Last Modified When]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[Last Modified When]"
+                          name="Last Modified When"
+                          scale="7"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[WWI Invoice ID]"
+                          dataType="i4"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[WWI Invoice ID]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[WWI Invoice ID]"
+                          name="WWI Invoice ID"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[Total Excluding Tax]"
+                          dataType="numeric"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[Total Excluding Tax]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[Total Excluding Tax]"
+                          name="Total Excluding Tax"
+                          precision="18"
+                          scale="2"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[Tax Amount]"
+                          dataType="numeric"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[Tax Amount]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[Tax Amount]"
+                          name="Tax Amount"
+                          precision="18"
+                          scale="2"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[Total Including Tax]"
+                          dataType="numeric"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[Total Including Tax]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[Total Including Tax]"
+                          name="Total Including Tax"
+                          precision="18"
+                          scale="2"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[WWI Customer ID]"
+                          dataType="i4"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[WWI Customer ID]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[WWI Customer ID]"
+                          name="WWI Customer ID"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[WWI Bill To Customer ID]"
+                          dataType="i4"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[WWI Bill To Customer ID]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[WWI Bill To Customer ID]"
+                          name="WWI Bill To Customer ID"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[Date Key]"
+                          dataType="dbDate"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[Date Key]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[Date Key]"
+                          name="Date Key"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[WWI Customer Transaction ID]"
+                          dataType="i4"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[WWI Customer Transaction ID]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[WWI Customer Transaction ID]"
+                          name="WWI Customer Transaction ID"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[WWI Supplier Transaction ID]"
+                          dataType="i4"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[WWI Supplier Transaction ID]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[WWI Supplier Transaction ID]"
+                          name="WWI Supplier Transaction ID"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[WWI Purchase Order ID]"
+                          dataType="i4"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[WWI Purchase Order ID]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[WWI Purchase Order ID]"
+                          name="WWI Purchase Order ID"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[Supplier Invoice Number]"
+                          dataType="wstr"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[Supplier Invoice Number]"
+                          length="20"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[Supplier Invoice Number]"
+                          name="Supplier Invoice Number"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[Outstanding Balance]"
+                          dataType="numeric"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[Outstanding Balance]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[Outstanding Balance]"
+                          name="Outstanding Balance"
+                          precision="18"
+                          scale="2"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[Is Finalized]"
+                          dataType="bool"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[Is Finalized]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[Is Finalized]"
+                          name="Is Finalized"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[WWI Supplier ID]"
+                          dataType="i4"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[WWI Supplier ID]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[WWI Supplier ID]"
+                          name="WWI Supplier ID"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[WWI Transaction Type ID]"
+                          dataType="i4"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[WWI Transaction Type ID]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[WWI Transaction Type ID]"
+                          name="WWI Transaction Type ID"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[WWI Payment Method ID]"
+                          dataType="i4"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[WWI Payment Method ID]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[WWI Payment Method ID]"
+                          name="WWI Payment Method ID"
+                          truncationRowDisposition="FailComponent" />
+                      </outputColumns>
+                      <externalMetadataColumns
+                        isUsed="True">
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[Last Modified When]"
+                          dataType="dbTimeStamp2"
+                          name="Last Modified When"
+                          scale="7" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[WWI Invoice ID]"
+                          dataType="i4"
+                          name="WWI Invoice ID" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[Total Excluding Tax]"
+                          dataType="numeric"
+                          name="Total Excluding Tax"
+                          precision="18"
+                          scale="2" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[Tax Amount]"
+                          dataType="numeric"
+                          name="Tax Amount"
+                          precision="18"
+                          scale="2" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[Total Including Tax]"
+                          dataType="numeric"
+                          name="Total Including Tax"
+                          precision="18"
+                          scale="2" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[WWI Customer ID]"
+                          dataType="i4"
+                          name="WWI Customer ID" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[WWI Bill To Customer ID]"
+                          dataType="i4"
+                          name="WWI Bill To Customer ID" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[Date Key]"
+                          dataType="dbDate"
+                          name="Date Key" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[WWI Customer Transaction ID]"
+                          dataType="i4"
+                          name="WWI Customer Transaction ID" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[WWI Supplier Transaction ID]"
+                          dataType="i4"
+                          name="WWI Supplier Transaction ID" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[WWI Purchase Order ID]"
+                          dataType="i4"
+                          name="WWI Purchase Order ID" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[Supplier Invoice Number]"
+                          dataType="wstr"
+                          length="20"
+                          name="Supplier Invoice Number" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[Outstanding Balance]"
+                          dataType="numeric"
+                          name="Outstanding Balance"
+                          precision="18"
+                          scale="2" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[Is Finalized]"
+                          dataType="bool"
+                          name="Is Finalized" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[WWI Supplier ID]"
+                          dataType="i4"
+                          name="WWI Supplier ID" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[WWI Transaction Type ID]"
+                          dataType="i4"
+                          name="WWI Transaction Type ID" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].ExternalColumns[WWI Payment Method ID]"
+                          dataType="i4"
+                          name="WWI Payment Method ID" />
+                      </externalMetadataColumns>
+                    </output>
+                    <output
+                      refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output]"
+                      isErrorOut="true"
+                      name="OLE DB Source Error Output">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[Date Key]"
+                          dataType="dbDate"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[Date Key]"
+                          name="Date Key" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[WWI Customer Transaction ID]"
+                          dataType="i4"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[WWI Customer Transaction ID]"
+                          name="WWI Customer Transaction ID" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[WWI Supplier Transaction ID]"
+                          dataType="i4"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[WWI Supplier Transaction ID]"
+                          name="WWI Supplier Transaction ID" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[WWI Invoice ID]"
+                          dataType="i4"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[WWI Invoice ID]"
+                          name="WWI Invoice ID" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[WWI Purchase Order ID]"
+                          dataType="i4"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[WWI Purchase Order ID]"
+                          name="WWI Purchase Order ID" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[Supplier Invoice Number]"
+                          dataType="wstr"
+                          length="20"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[Supplier Invoice Number]"
+                          name="Supplier Invoice Number" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[Total Excluding Tax]"
+                          dataType="numeric"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[Total Excluding Tax]"
+                          name="Total Excluding Tax"
+                          precision="18"
+                          scale="2" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[Tax Amount]"
+                          dataType="numeric"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[Tax Amount]"
+                          name="Tax Amount"
+                          precision="18"
+                          scale="2" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[Total Including Tax]"
+                          dataType="numeric"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[Total Including Tax]"
+                          name="Total Including Tax"
+                          precision="18"
+                          scale="2" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[Outstanding Balance]"
+                          dataType="numeric"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[Outstanding Balance]"
+                          name="Outstanding Balance"
+                          precision="18"
+                          scale="2" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[Is Finalized]"
+                          dataType="bool"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[Is Finalized]"
+                          name="Is Finalized" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[WWI Customer ID]"
+                          dataType="i4"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[WWI Customer ID]"
+                          name="WWI Customer ID" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[WWI Bill To Customer ID]"
+                          dataType="i4"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[WWI Bill To Customer ID]"
+                          name="WWI Bill To Customer ID" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[WWI Supplier ID]"
+                          dataType="i4"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[WWI Supplier ID]"
+                          name="WWI Supplier ID" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[WWI Transaction Type ID]"
+                          dataType="i4"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[WWI Transaction Type ID]"
+                          name="WWI Transaction Type ID" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[WWI Payment Method ID]"
+                          dataType="i4"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[WWI Payment Method ID]"
+                          name="WWI Payment Method ID" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[Last Modified When]"
+                          dataType="dbTimeStamp2"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[Last Modified When]"
+                          name="Last Modified When"
+                          scale="7" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                          dataType="i4"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                          name="ErrorCode"
+                          specialFlags="1" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                          dataType="i4"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                          name="ErrorColumn"
+                          specialFlags="2" />
+                      </outputColumns>
+                      <externalMetadataColumns />
+                    </output>
+                  </outputs>
+                </component>
+                <component
+                  refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging"
+                  componentClassID="Microsoft.OLEDBDestination"
+                  contactInfo="OLE DB Destination;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;4"
+                  description="OLE DB Destination"
+                  name="Integration_Transaction_Staging"
+                  usesDispositions="true"
+                  version="4">
+                  <properties>
+                    <property
+                      dataType="System.Int32"
+                      description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                      name="CommandTimeout">0</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the name of the database object used to open a rowset."
+                      name="OpenRowset">[Integration].[Transaction_Staging]</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the variable that contains the name of the database object used to open a rowset."
+                      name="OpenRowsetVariable"></property>
+                    <property
+                      dataType="System.String"
+                      description="The SQL command to be executed."
+                      name="SqlCommand"
+                      UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=16.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91"></property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the column code page to use when code page information is unavailable from the data source."
+                      name="DefaultCodePage">1252</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Forces the use of the DefaultCodePage property value when describing character data."
+                      name="AlwaysUseDefaultCodePage">false</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the mode used to access the database."
+                      name="AccessMode"
+                      typeConverter="AccessMode">3</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Indicates whether the values supplied for identity columns will be copied to the destination. If false, values for identity columns will be auto-generated at the destination. Applies only if fast load is turned on."
+                      name="FastLoadKeepIdentity">false</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Indicates whether the columns containing null will have null inserted in the destination. If false, columns containing null will have their default values inserted at the destination. Applies only if fast load is turned on."
+                      name="FastLoadKeepNulls">false</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies options to be used with fast load.  Applies only if fast load is turned on."
+                      name="FastLoadOptions">CHECK_CONSTRAINTS</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies when commits are issued during data insertion.  A value of 0 specifies that one commit will be issued at the end of data insertion.  Applies only if fast load is turned on."
+                      name="FastLoadMaxInsertCommitSize">2147483647</property>
+                  </properties>
+                  <connections>
+                    <connection
+                      refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Connections[OleDbConnection]"
+                      connectionManagerID="{7C3E3ECC-C5AD-4675-9618-FC08465F8BC9}:external"
+                      connectionManagerRefId="Project.ConnectionManagers[WWI_DW_Destination_DB]"
+                      description="The OLE DB runtime connection used to access the database."
+                      name="OleDbConnection" />
+                  </connections>
+                  <inputs>
+                    <input
+                      refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input]"
+                      errorOrTruncationOperation="Insert"
+                      errorRowDisposition="FailComponent"
+                      hasSideEffects="true"
+                      name="OLE DB Destination Input">
+                      <inputColumns>
+                        <inputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].Columns[Last Modified When]"
+                          cachedDataType="dbTimeStamp2"
+                          cachedName="Last Modified When"
+                          cachedScale="7"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Last Modified When]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[Last Modified When]" />
+                        <inputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].Columns[WWI Invoice ID]"
+                          cachedDataType="i4"
+                          cachedName="WWI Invoice ID"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[WWI Invoice ID]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[WWI Invoice ID]" />
+                        <inputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].Columns[Total Excluding Tax]"
+                          cachedDataType="numeric"
+                          cachedName="Total Excluding Tax"
+                          cachedPrecision="18"
+                          cachedScale="2"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Total Excluding Tax]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[Total Excluding Tax]" />
+                        <inputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].Columns[Tax Amount]"
+                          cachedDataType="numeric"
+                          cachedName="Tax Amount"
+                          cachedPrecision="18"
+                          cachedScale="2"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Tax Amount]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[Tax Amount]" />
+                        <inputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].Columns[Total Including Tax]"
+                          cachedDataType="numeric"
+                          cachedName="Total Including Tax"
+                          cachedPrecision="18"
+                          cachedScale="2"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Total Including Tax]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[Total Including Tax]" />
+                        <inputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].Columns[WWI Customer ID]"
+                          cachedDataType="i4"
+                          cachedName="WWI Customer ID"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[WWI Customer ID]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[WWI Customer ID]" />
+                        <inputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].Columns[WWI Bill To Customer ID]"
+                          cachedDataType="i4"
+                          cachedName="WWI Bill To Customer ID"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[WWI Bill To Customer ID]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[WWI Bill To Customer ID]" />
+                        <inputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].Columns[Date Key]"
+                          cachedDataType="dbDate"
+                          cachedName="Date Key"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Date Key]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[Date Key]" />
+                        <inputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].Columns[WWI Customer Transaction ID]"
+                          cachedDataType="i4"
+                          cachedName="WWI Customer Transaction ID"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[WWI Customer Transaction ID]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[WWI Customer Transaction ID]" />
+                        <inputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].Columns[WWI Supplier Transaction ID]"
+                          cachedDataType="i4"
+                          cachedName="WWI Supplier Transaction ID"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[WWI Supplier Transaction ID]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[WWI Supplier Transaction ID]" />
+                        <inputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].Columns[WWI Purchase Order ID]"
+                          cachedDataType="i4"
+                          cachedName="WWI Purchase Order ID"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[WWI Purchase Order ID]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[WWI Purchase Order ID]" />
+                        <inputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].Columns[Supplier Invoice Number]"
+                          cachedDataType="wstr"
+                          cachedLength="20"
+                          cachedName="Supplier Invoice Number"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Supplier Invoice Number]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[Supplier Invoice Number]" />
+                        <inputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].Columns[Outstanding Balance]"
+                          cachedDataType="numeric"
+                          cachedName="Outstanding Balance"
+                          cachedPrecision="18"
+                          cachedScale="2"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Outstanding Balance]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[Outstanding Balance]" />
+                        <inputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].Columns[Is Finalized]"
+                          cachedDataType="bool"
+                          cachedName="Is Finalized"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Is Finalized]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[Is Finalized]" />
+                        <inputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].Columns[WWI Supplier ID]"
+                          cachedDataType="i4"
+                          cachedName="WWI Supplier ID"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[WWI Supplier ID]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[WWI Supplier ID]" />
+                        <inputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].Columns[WWI Transaction Type ID]"
+                          cachedDataType="i4"
+                          cachedName="WWI Transaction Type ID"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[WWI Transaction Type ID]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[WWI Transaction Type ID]" />
+                        <inputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].Columns[WWI Payment Method ID]"
+                          cachedDataType="i4"
+                          cachedName="WWI Payment Method ID"
+                          externalMetadataColumnId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[WWI Payment Method ID]"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output].Columns[WWI Payment Method ID]" />
+                      </inputColumns>
+                      <externalMetadataColumns
+                        isUsed="True">
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Last Modified When]"
+                          dataType="dbTimeStamp2"
+                          name="Last Modified When"
+                          scale="7" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Customer Key]"
+                          dataType="i4"
+                          name="Customer Key" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Bill To Customer Key]"
+                          dataType="i4"
+                          name="Bill To Customer Key" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[WWI Invoice ID]"
+                          dataType="i4"
+                          name="WWI Invoice ID" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Total Excluding Tax]"
+                          dataType="numeric"
+                          name="Total Excluding Tax"
+                          precision="18"
+                          scale="2" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Tax Amount]"
+                          dataType="numeric"
+                          name="Tax Amount"
+                          precision="18"
+                          scale="2" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Total Including Tax]"
+                          dataType="numeric"
+                          name="Total Including Tax"
+                          precision="18"
+                          scale="2" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[WWI Customer ID]"
+                          dataType="i4"
+                          name="WWI Customer ID" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[WWI Bill To Customer ID]"
+                          dataType="i4"
+                          name="WWI Bill To Customer ID" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Transaction Staging Key]"
+                          dataType="i8"
+                          name="Transaction Staging Key" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Date Key]"
+                          dataType="dbDate"
+                          name="Date Key" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Supplier Key]"
+                          dataType="i4"
+                          name="Supplier Key" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Transaction Type Key]"
+                          dataType="i4"
+                          name="Transaction Type Key" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Payment Method Key]"
+                          dataType="i4"
+                          name="Payment Method Key" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[WWI Customer Transaction ID]"
+                          dataType="i4"
+                          name="WWI Customer Transaction ID" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[WWI Supplier Transaction ID]"
+                          dataType="i4"
+                          name="WWI Supplier Transaction ID" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[WWI Purchase Order ID]"
+                          dataType="i4"
+                          name="WWI Purchase Order ID" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Supplier Invoice Number]"
+                          dataType="wstr"
+                          length="20"
+                          name="Supplier Invoice Number" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Outstanding Balance]"
+                          dataType="numeric"
+                          name="Outstanding Balance"
+                          precision="18"
+                          scale="2" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Is Finalized]"
+                          dataType="bool"
+                          name="Is Finalized" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[WWI Supplier ID]"
+                          dataType="i4"
+                          name="WWI Supplier ID" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[WWI Transaction Type ID]"
+                          dataType="i4"
+                          name="WWI Transaction Type ID" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input].ExternalColumns[WWI Payment Method ID]"
+                          dataType="i4"
+                          name="WWI Payment Method ID" />
+                      </externalMetadataColumns>
+                    </input>
+                  </inputs>
+                  <outputs>
+                    <output
+                      refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Outputs[OLE DB Destination Error Output]"
+                      exclusionGroup="1"
+                      isErrorOut="true"
+                      name="OLE DB Destination Error Output"
+                      synchronousInputId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input]">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                          dataType="i4"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                          name="ErrorCode"
+                          specialFlags="1" />
+                        <outputColumn
+                          refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                          dataType="i4"
+                          lineageId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                          name="ErrorColumn"
+                          specialFlags="2" />
+                      </outputColumns>
+                      <externalMetadataColumns />
+                    </output>
+                  </outputs>
+                </component>
+              </components>
+              <paths>
+                <path
+                  refId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging.Paths[OLE DB Source Output]"
+                  endId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging.Inputs[OLE DB Destination Input]"
+                  name="OLE DB Source Output"
+                  startId="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates.Outputs[OLE DB Source Output]" />
+              </paths>
+            </pipeline>
+          </DTS:ObjectData>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Load Transaction Fact\Get Last Movement ETL Cutoff Time"
+          DTS:CreationName="Microsoft.ExecuteSQLTask"
+          DTS:Description="Execute SQL Task"
+          DTS:DTSID="{6cf44941-c9ff-47c3-936e-9e8f4d62f2ef}"
+          DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Get Last Movement ETL Cutoff Time"
+          DTS:TaskContact="Execute SQL Task; Microsoft Corporation; SQL Server 2016 RC2; © 2015 Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1"
+          DTS:ThreadHint="0">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <SQLTask:SqlTaskData
+              SQLTask:Connection="{7C3E3ECC-C5AD-4675-9618-FC08465F8BC9}"
+              SQLTask:SqlStatementSource="EXEC Integration.GetLastETLCutoffTime ?;"
+              SQLTask:ResultType="ResultSetType_SingleRow" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask">
+              <SQLTask:ResultBinding
+                SQLTask:ResultName="CutoffTime"
+                SQLTask:DtsVariableName="User::LastETLCutoffTime" />
+              <SQLTask:ParameterBinding
+                SQLTask:ParameterName="0"
+                SQLTask:DtsVariableName="User::TableName"
+                SQLTask:ParameterDirection="Input"
+                SQLTask:DataType="130"
+                SQLTask:ParameterSize="-1" />
+            </SQLTask:SqlTaskData>
+          </DTS:ObjectData>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Load Transaction Fact\Get Lineage Key"
+          DTS:CreationName="Microsoft.ExecuteSQLTask"
+          DTS:Description="Execute SQL Task"
+          DTS:DTSID="{0a41da98-006d-4ade-a997-8362ea6369f0}"
+          DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Get Lineage Key"
+          DTS:TaskContact="Execute SQL Task; Microsoft Corporation; SQL Server 2016 RC2; © 2015 Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1"
+          DTS:ThreadHint="0">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <SQLTask:SqlTaskData
+              SQLTask:Connection="{7C3E3ECC-C5AD-4675-9618-FC08465F8BC9}"
+              SQLTask:SqlStatementSource="EXEC Integration.GetLineageKey ?, ?;"
+              SQLTask:ResultType="ResultSetType_SingleRow" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask">
+              <SQLTask:ResultBinding
+                SQLTask:ResultName="LineageKey"
+                SQLTask:DtsVariableName="User::LineageKey" />
+              <SQLTask:ParameterBinding
+                SQLTask:ParameterName="0"
+                SQLTask:DtsVariableName="User::TableName"
+                SQLTask:ParameterDirection="Input"
+                SQLTask:DataType="130"
+                SQLTask:ParameterSize="-1" />
+              <SQLTask:ParameterBinding
+                SQLTask:ParameterName="1"
+                SQLTask:DtsVariableName="User::TargetETLCutoffTime"
+                SQLTask:ParameterDirection="Input"
+                SQLTask:DataType="7"
+                SQLTask:ParameterSize="-1" />
+            </SQLTask:SqlTaskData>
+          </DTS:ObjectData>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Load Transaction Fact\Migrate Staged Transaction Data"
+          DTS:CreationName="Microsoft.ExecuteSQLTask"
+          DTS:Description="Execute SQL Task"
+          DTS:DTSID="{b7c7e2e9-7f3d-498b-972c-c8bafd638894}"
+          DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Migrate Staged Transaction Data"
+          DTS:TaskContact="Execute SQL Task; Microsoft Corporation; SQL Server 2016 RC2; © 2015 Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1"
+          DTS:ThreadHint="0">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <SQLTask:SqlTaskData
+              SQLTask:Connection="{7C3E3ECC-C5AD-4675-9618-FC08465F8BC9}"
+              SQLTask:SqlStatementSource="EXEC Integration.MigrateStagedTransactionData;" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask" />
+          </DTS:ObjectData>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Load Transaction Fact\Set TableName to Transaction"
+          DTS:CreationName="Microsoft.ExpressionTask"
+          DTS:Description="Expression Task"
+          DTS:DTSID="{6668b03e-3e51-4538-a736-520e7cdcf4cf}"
+          DTS:ExecutableType="Microsoft.ExpressionTask"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Set TableName to Transaction"
+          DTS:TaskContact="Expression Task;Microsoft Corporation; SQL Server 2016 RC2; © 2015 Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1"
+          DTS:ThreadHint="0">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <ExpressionTask
+              Expression="@[User::TableName] = &quot;Transaction&quot;" />
+          </DTS:ObjectData>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Load Transaction Fact\Truncate Transaction_Staging"
+          DTS:CreationName="Microsoft.ExecuteSQLTask"
+          DTS:Description="Execute SQL Task"
+          DTS:DTSID="{a95522d3-3e5a-446e-b951-a9f5f4578fe1}"
+          DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Truncate Transaction_Staging"
+          DTS:TaskContact="Execute SQL Task; Microsoft Corporation; SQL Server 2016 RC2; © 2015 Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1"
+          DTS:ThreadHint="0">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <SQLTask:SqlTaskData
+              SQLTask:Connection="{7C3E3ECC-C5AD-4675-9618-FC08465F8BC9}"
+              SQLTask:SqlStatementSource="DELETE FROM Integration.Transaction_Staging;" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask" />
+          </DTS:ObjectData>
+        </DTS:Executable>
+      </DTS:Executables>
+      <DTS:PrecedenceConstraints>
+        <DTS:PrecedenceConstraint
+          DTS:refId="Package\Load Transaction Fact.PrecedenceConstraints[Constraint]"
+          DTS:CreationName=""
+          DTS:DTSID="{93bc7210-e2ca-4da5-b6e9-94297d6ae0d3}"
+          DTS:From="Package\Load Transaction Fact\Set TableName to Transaction"
+          DTS:LogicalAnd="True"
+          DTS:ObjectName="Constraint"
+          DTS:To="Package\Load Transaction Fact\Get Lineage Key" />
+        <DTS:PrecedenceConstraint
+          DTS:refId="Package\Load Transaction Fact.PrecedenceConstraints[Constraint 1]"
+          DTS:CreationName=""
+          DTS:DTSID="{15ce7169-3983-4eaa-b5c9-3445b69561d1}"
+          DTS:From="Package\Load Transaction Fact\Get Lineage Key"
+          DTS:LogicalAnd="True"
+          DTS:ObjectName="Constraint 1"
+          DTS:To="Package\Load Transaction Fact\Truncate Transaction_Staging" />
+        <DTS:PrecedenceConstraint
+          DTS:refId="Package\Load Transaction Fact.PrecedenceConstraints[Constraint 2]"
+          DTS:CreationName=""
+          DTS:DTSID="{ce0bfd9f-1f82-4747-8e94-4d1e4388fba3}"
+          DTS:From="Package\Load Transaction Fact\Truncate Transaction_Staging"
+          DTS:LogicalAnd="True"
+          DTS:ObjectName="Constraint 2"
+          DTS:To="Package\Load Transaction Fact\Get Last Movement ETL Cutoff Time" />
+        <DTS:PrecedenceConstraint
+          DTS:refId="Package\Load Transaction Fact.PrecedenceConstraints[Constraint 3]"
+          DTS:CreationName=""
+          DTS:DTSID="{6a324cfe-91b8-4e2f-a4e2-c3d93f483ca0}"
+          DTS:From="Package\Load Transaction Fact\Get Last Movement ETL Cutoff Time"
+          DTS:LogicalAnd="True"
+          DTS:ObjectName="Constraint 3"
+          DTS:To="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging" />
+        <DTS:PrecedenceConstraint
+          DTS:refId="Package\Load Transaction Fact.PrecedenceConstraints[Constraint 4]"
+          DTS:CreationName=""
+          DTS:DTSID="{6ce8e6a1-1af0-4e95-b2ea-d74b17d6a9d0}"
+          DTS:From="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging"
+          DTS:LogicalAnd="True"
+          DTS:ObjectName="Constraint 4"
+          DTS:To="Package\Load Transaction Fact\Migrate Staged Transaction Data" />
+      </DTS:PrecedenceConstraints>
+    </DTS:Executable>
+    <DTS:Executable
+      DTS:refId="Package\Load Transaction Type Dimension"
+      DTS:CreationName="STOCK:SEQUENCE"
+      DTS:Description="Sequence Container"
+      DTS:DTSID="{92EF3B4B-D631-4891-95DD-1700E09B18D2}"
+      DTS:ExecutableType="STOCK:SEQUENCE"
+      DTS:LocaleID="-1"
+      DTS:ObjectName="Load Transaction Type Dimension">
+      <DTS:Variables />
+      <DTS:Executables>
+        <DTS:Executable
+          DTS:refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging"
+          DTS:CreationName="Microsoft.Pipeline"
+          DTS:Description="Data Flow Task"
+          DTS:DTSID="{9228b7ce-7fdf-4781-aeb3-abb4198da89a}"
+          DTS:ExecutableType="Microsoft.Pipeline"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Extract Updated Transaction Type Data to Staging"
+          DTS:TaskContact="Performs high-performance data extraction, transformation and loading;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <pipeline
+              version="1">
+              <components>
+                <component
+                  refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates"
+                  componentClassID="Microsoft.OLEDBSource"
+                  contactInfo="OLE DB Source;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;7"
+                  description="OLE DB Source"
+                  name="Integration_GetTransactionTypeUpdates"
+                  usesDispositions="true"
+                  version="7">
+                  <properties>
+                    <property
+                      dataType="System.Int32"
+                      description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                      name="CommandTimeout">0</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the name of the database object used to open a rowset."
+                      name="OpenRowset"></property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the variable that contains the name of the database object used to open a rowset."
+                      name="OpenRowsetVariable"></property>
+                    <property
+                      dataType="System.String"
+                      description="The SQL command to be executed."
+                      name="SqlCommand"
+                      UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=16.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91">EXEC Integration.GetTransactionTypeUpdates ?, ?
+WITH RESULT SETS
+(
+    (
+        [WWI Transaction Type ID] int,
+        [Transaction Type] nvarchar(50),
+        [Valid From] datetime2(7),
+        [Valid To] datetime2(7)
+    )
+);</property>
+                    <property
+                      dataType="System.String"
+                      description="The variable that contains the SQL command to be executed."
+                      name="SqlCommandVariable"></property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the column code page to use when code page information is unavailable from the data source."
+                      name="DefaultCodePage">1252</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Forces the use of the DefaultCodePage property value when describing character data."
+                      name="AlwaysUseDefaultCodePage">false</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the mode used to access the database."
+                      name="AccessMode"
+                      typeConverter="AccessMode">2</property>
+                    <property
+                      dataType="System.String"
+                      description="The mappings between the parameters in the SQL command and variables."
+                      name="ParameterMapping">"@LastCutoff:Input",{60BD9010-4784-49A6-8FF2-340D7AB3B70D};"@NewCutoff:Input",{B96D08A3-EC4E-45C1-8E78-526920753C6B};</property>
+                  </properties>
+                  <connections>
+                    <connection
+                      refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Connections[OleDbConnection]"
+                      connectionManagerID="{E8464E14-D126-4B86-AFFB-295B0D3506F4}:external"
+                      connectionManagerRefId="Project.ConnectionManagers[WWI_Source_DB]"
+                      description="The OLE DB runtime connection used to access the database."
+                      name="OleDbConnection" />
+                  </connections>
+                  <outputs>
+                    <output
+                      refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Output]"
+                      name="OLE DB Source Output">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Output].Columns[Valid From]"
+                          dataType="dbTimeStamp2"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Output].ExternalColumns[Valid From]"
+                          lineageId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Output].Columns[Valid From]"
+                          name="Valid From"
+                          scale="7"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Output].Columns[Valid To]"
+                          dataType="dbTimeStamp2"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Output].ExternalColumns[Valid To]"
+                          lineageId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Output].Columns[Valid To]"
+                          name="Valid To"
+                          scale="7"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Output].Columns[WWI Transaction Type ID]"
+                          dataType="i4"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Output].ExternalColumns[WWI Transaction Type ID]"
+                          lineageId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Output].Columns[WWI Transaction Type ID]"
+                          name="WWI Transaction Type ID"
+                          truncationRowDisposition="FailComponent" />
+                        <outputColumn
+                          refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Output].Columns[Transaction Type]"
+                          dataType="wstr"
+                          errorOrTruncationOperation="Conversion"
+                          errorRowDisposition="FailComponent"
+                          externalMetadataColumnId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Output].ExternalColumns[Transaction Type]"
+                          length="50"
+                          lineageId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Output].Columns[Transaction Type]"
+                          name="Transaction Type"
+                          truncationRowDisposition="FailComponent" />
+                      </outputColumns>
+                      <externalMetadataColumns
+                        isUsed="True">
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Output].ExternalColumns[Valid From]"
+                          dataType="dbTimeStamp2"
+                          name="Valid From"
+                          scale="7" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Output].ExternalColumns[Valid To]"
+                          dataType="dbTimeStamp2"
+                          name="Valid To"
+                          scale="7" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Output].ExternalColumns[WWI Transaction Type ID]"
+                          dataType="i4"
+                          name="WWI Transaction Type ID" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Output].ExternalColumns[Transaction Type]"
+                          dataType="wstr"
+                          length="50"
+                          name="Transaction Type" />
+                      </externalMetadataColumns>
+                    </output>
+                    <output
+                      refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Error Output]"
+                      isErrorOut="true"
+                      name="OLE DB Source Error Output">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Error Output].Columns[WWI Transaction Type ID]"
+                          dataType="i4"
+                          lineageId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Error Output].Columns[WWI Transaction Type ID]"
+                          name="WWI Transaction Type ID" />
+                        <outputColumn
+                          refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Error Output].Columns[Transaction Type]"
+                          dataType="wstr"
+                          length="50"
+                          lineageId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Error Output].Columns[Transaction Type]"
+                          name="Transaction Type" />
+                        <outputColumn
+                          refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Error Output].Columns[Valid From]"
+                          dataType="dbTimeStamp2"
+                          lineageId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Error Output].Columns[Valid From]"
+                          name="Valid From"
+                          scale="7" />
+                        <outputColumn
+                          refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Error Output].Columns[Valid To]"
+                          dataType="dbTimeStamp2"
+                          lineageId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Error Output].Columns[Valid To]"
+                          name="Valid To"
+                          scale="7" />
+                        <outputColumn
+                          refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                          dataType="i4"
+                          lineageId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Error Output].Columns[ErrorCode]"
+                          name="ErrorCode"
+                          specialFlags="1" />
+                        <outputColumn
+                          refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                          dataType="i4"
+                          lineageId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Error Output].Columns[ErrorColumn]"
+                          name="ErrorColumn"
+                          specialFlags="2" />
+                      </outputColumns>
+                      <externalMetadataColumns />
+                    </output>
+                  </outputs>
+                </component>
+                <component
+                  refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_TransactionType_Staging"
+                  componentClassID="Microsoft.OLEDBDestination"
+                  contactInfo="OLE DB Destination;Microsoft Corporation; Microsoft SQL Server; (C) Microsoft Corporation; All Rights Reserved; http://www.microsoft.com/sql/support;4"
+                  description="OLE DB Destination"
+                  name="Integration_TransactionType_Staging"
+                  usesDispositions="true"
+                  version="4">
+                  <properties>
+                    <property
+                      dataType="System.Int32"
+                      description="The number of seconds before a command times out.  A value of 0 indicates an infinite time-out."
+                      name="CommandTimeout">0</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the name of the database object used to open a rowset."
+                      name="OpenRowset">[Integration].[TransactionType_Staging]</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies the variable that contains the name of the database object used to open a rowset."
+                      name="OpenRowsetVariable"></property>
+                    <property
+                      dataType="System.String"
+                      description="The SQL command to be executed."
+                      name="SqlCommand"
+                      UITypeEditor="Microsoft.DataTransformationServices.Controls.ModalMultilineStringEditor, Microsoft.DataTransformationServices.Controls, Version=16.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91"></property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the column code page to use when code page information is unavailable from the data source."
+                      name="DefaultCodePage">1252</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Forces the use of the DefaultCodePage property value when describing character data."
+                      name="AlwaysUseDefaultCodePage">false</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies the mode used to access the database."
+                      name="AccessMode"
+                      typeConverter="AccessMode">3</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Indicates whether the values supplied for identity columns will be copied to the destination. If false, values for identity columns will be auto-generated at the destination. Applies only if fast load is turned on."
+                      name="FastLoadKeepIdentity">false</property>
+                    <property
+                      dataType="System.Boolean"
+                      description="Indicates whether the columns containing null will have null inserted in the destination. If false, columns containing null will have their default values inserted at the destination. Applies only if fast load is turned on."
+                      name="FastLoadKeepNulls">false</property>
+                    <property
+                      dataType="System.String"
+                      description="Specifies options to be used with fast load.  Applies only if fast load is turned on."
+                      name="FastLoadOptions">CHECK_CONSTRAINTS</property>
+                    <property
+                      dataType="System.Int32"
+                      description="Specifies when commits are issued during data insertion.  A value of 0 specifies that one commit will be issued at the end of data insertion.  Applies only if fast load is turned on."
+                      name="FastLoadMaxInsertCommitSize">2147483647</property>
+                  </properties>
+                  <connections>
+                    <connection
+                      refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_TransactionType_Staging.Connections[OleDbConnection]"
+                      connectionManagerID="{7C3E3ECC-C5AD-4675-9618-FC08465F8BC9}:external"
+                      connectionManagerRefId="Project.ConnectionManagers[WWI_DW_Destination_DB]"
+                      description="The OLE DB runtime connection used to access the database."
+                      name="OleDbConnection" />
+                  </connections>
+                  <inputs>
+                    <input
+                      refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_TransactionType_Staging.Inputs[OLE DB Destination Input]"
+                      errorOrTruncationOperation="Insert"
+                      errorRowDisposition="FailComponent"
+                      hasSideEffects="true"
+                      name="OLE DB Destination Input">
+                      <inputColumns>
+                        <inputColumn
+                          refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_TransactionType_Staging.Inputs[OLE DB Destination Input].Columns[Valid From]"
+                          cachedDataType="dbTimeStamp2"
+                          cachedName="Valid From"
+                          cachedScale="7"
+                          externalMetadataColumnId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_TransactionType_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Valid From]"
+                          lineageId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Output].Columns[Valid From]" />
+                        <inputColumn
+                          refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_TransactionType_Staging.Inputs[OLE DB Destination Input].Columns[Valid To]"
+                          cachedDataType="dbTimeStamp2"
+                          cachedName="Valid To"
+                          cachedScale="7"
+                          externalMetadataColumnId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_TransactionType_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Valid To]"
+                          lineageId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Output].Columns[Valid To]" />
+                        <inputColumn
+                          refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_TransactionType_Staging.Inputs[OLE DB Destination Input].Columns[WWI Transaction Type ID]"
+                          cachedDataType="i4"
+                          cachedName="WWI Transaction Type ID"
+                          externalMetadataColumnId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_TransactionType_Staging.Inputs[OLE DB Destination Input].ExternalColumns[WWI Transaction Type ID]"
+                          lineageId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Output].Columns[WWI Transaction Type ID]" />
+                        <inputColumn
+                          refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_TransactionType_Staging.Inputs[OLE DB Destination Input].Columns[Transaction Type]"
+                          cachedDataType="wstr"
+                          cachedLength="50"
+                          cachedName="Transaction Type"
+                          externalMetadataColumnId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_TransactionType_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Transaction Type]"
+                          lineageId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Output].Columns[Transaction Type]" />
+                      </inputColumns>
+                      <externalMetadataColumns
+                        isUsed="True">
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_TransactionType_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Valid From]"
+                          dataType="dbTimeStamp2"
+                          name="Valid From"
+                          scale="7" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_TransactionType_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Valid To]"
+                          dataType="dbTimeStamp2"
+                          name="Valid To"
+                          scale="7" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_TransactionType_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Transaction Type Staging Key]"
+                          dataType="i4"
+                          name="Transaction Type Staging Key" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_TransactionType_Staging.Inputs[OLE DB Destination Input].ExternalColumns[WWI Transaction Type ID]"
+                          dataType="i4"
+                          name="WWI Transaction Type ID" />
+                        <externalMetadataColumn
+                          refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_TransactionType_Staging.Inputs[OLE DB Destination Input].ExternalColumns[Transaction Type]"
+                          dataType="wstr"
+                          length="50"
+                          name="Transaction Type" />
+                      </externalMetadataColumns>
+                    </input>
+                  </inputs>
+                  <outputs>
+                    <output
+                      refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_TransactionType_Staging.Outputs[OLE DB Destination Error Output]"
+                      exclusionGroup="1"
+                      isErrorOut="true"
+                      name="OLE DB Destination Error Output"
+                      synchronousInputId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_TransactionType_Staging.Inputs[OLE DB Destination Input]">
+                      <outputColumns>
+                        <outputColumn
+                          refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_TransactionType_Staging.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                          dataType="i4"
+                          lineageId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_TransactionType_Staging.Outputs[OLE DB Destination Error Output].Columns[ErrorCode]"
+                          name="ErrorCode"
+                          specialFlags="1" />
+                        <outputColumn
+                          refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_TransactionType_Staging.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                          dataType="i4"
+                          lineageId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_TransactionType_Staging.Outputs[OLE DB Destination Error Output].Columns[ErrorColumn]"
+                          name="ErrorColumn"
+                          specialFlags="2" />
+                      </outputColumns>
+                      <externalMetadataColumns />
+                    </output>
+                  </outputs>
+                </component>
+              </components>
+              <paths>
+                <path
+                  refId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging.Paths[OLE DB Source Output]"
+                  endId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_TransactionType_Staging.Inputs[OLE DB Destination Input]"
+                  name="OLE DB Source Output"
+                  startId="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates.Outputs[OLE DB Source Output]" />
+              </paths>
+            </pipeline>
+          </DTS:ObjectData>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Load Transaction Type Dimension\Get Last Transaction Type ETL Cutoff Time"
+          DTS:CreationName="Microsoft.ExecuteSQLTask"
+          DTS:Description="Execute SQL Task"
+          DTS:DTSID="{065e4c54-b778-4bba-b541-a4ff2377f118}"
+          DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Get Last Transaction Type ETL Cutoff Time"
+          DTS:TaskContact="Execute SQL Task; Microsoft Corporation; SQL Server 2016 RC2; © 2015 Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1"
+          DTS:ThreadHint="0">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <SQLTask:SqlTaskData
+              SQLTask:Connection="{7C3E3ECC-C5AD-4675-9618-FC08465F8BC9}"
+              SQLTask:SqlStatementSource="EXEC Integration.GetLastETLCutoffTime ?;"
+              SQLTask:ResultType="ResultSetType_SingleRow" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask">
+              <SQLTask:ResultBinding
+                SQLTask:ResultName="CutoffTime"
+                SQLTask:DtsVariableName="User::LastETLCutoffTime" />
+              <SQLTask:ParameterBinding
+                SQLTask:ParameterName="0"
+                SQLTask:DtsVariableName="User::TableName"
+                SQLTask:ParameterDirection="Input"
+                SQLTask:DataType="130"
+                SQLTask:ParameterSize="-1" />
+            </SQLTask:SqlTaskData>
+          </DTS:ObjectData>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Load Transaction Type Dimension\Get Lineage Key"
+          DTS:CreationName="Microsoft.ExecuteSQLTask"
+          DTS:Description="Execute SQL Task"
+          DTS:DTSID="{1aa2f784-6039-4a96-81f1-13a278f7f698}"
+          DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Get Lineage Key"
+          DTS:TaskContact="Execute SQL Task; Microsoft Corporation; SQL Server 2016 RC2; © 2015 Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1"
+          DTS:ThreadHint="0">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <SQLTask:SqlTaskData
+              SQLTask:Connection="{7C3E3ECC-C5AD-4675-9618-FC08465F8BC9}"
+              SQLTask:SqlStatementSource="EXEC Integration.GetLineageKey ?, ?;"
+              SQLTask:ResultType="ResultSetType_SingleRow" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask">
+              <SQLTask:ResultBinding
+                SQLTask:ResultName="LineageKey"
+                SQLTask:DtsVariableName="User::LineageKey" />
+              <SQLTask:ParameterBinding
+                SQLTask:ParameterName="0"
+                SQLTask:DtsVariableName="User::TableName"
+                SQLTask:ParameterDirection="Input"
+                SQLTask:DataType="130"
+                SQLTask:ParameterSize="-1" />
+              <SQLTask:ParameterBinding
+                SQLTask:ParameterName="1"
+                SQLTask:DtsVariableName="User::TargetETLCutoffTime"
+                SQLTask:ParameterDirection="Input"
+                SQLTask:DataType="7"
+                SQLTask:ParameterSize="-1" />
+            </SQLTask:SqlTaskData>
+          </DTS:ObjectData>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Load Transaction Type Dimension\Migrate Staged Transaction Type Data"
+          DTS:CreationName="Microsoft.ExecuteSQLTask"
+          DTS:Description="Execute SQL Task"
+          DTS:DTSID="{949e4f8a-e51f-489c-a195-0610db8fe70f}"
+          DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Migrate Staged Transaction Type Data"
+          DTS:TaskContact="Execute SQL Task; Microsoft Corporation; SQL Server 2016 RC2; © 2015 Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1"
+          DTS:ThreadHint="0">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <SQLTask:SqlTaskData
+              SQLTask:Connection="{7C3E3ECC-C5AD-4675-9618-FC08465F8BC9}"
+              SQLTask:SqlStatementSource="EXEC Integration.MigrateStagedTransactionTypeData;" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask" />
+          </DTS:ObjectData>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Load Transaction Type Dimension\Set TableName to Transaction Type"
+          DTS:CreationName="Microsoft.ExpressionTask"
+          DTS:Description="Expression Task"
+          DTS:DTSID="{2793f1b1-97be-4459-8765-1f4e8df2d798}"
+          DTS:ExecutableType="Microsoft.ExpressionTask"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Set TableName to Transaction Type"
+          DTS:TaskContact="Expression Task;Microsoft Corporation; SQL Server 2016 RC2; © 2015 Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1"
+          DTS:ThreadHint="0">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <ExpressionTask
+              Expression="@[User::TableName] = &quot;Transaction Type&quot;" />
+          </DTS:ObjectData>
+        </DTS:Executable>
+        <DTS:Executable
+          DTS:refId="Package\Load Transaction Type Dimension\Truncate TransactionType_Staging"
+          DTS:CreationName="Microsoft.ExecuteSQLTask"
+          DTS:Description="Execute SQL Task"
+          DTS:DTSID="{c70231df-1c58-42c5-a57a-04214a4556c0}"
+          DTS:ExecutableType="Microsoft.ExecuteSQLTask"
+          DTS:LocaleID="-1"
+          DTS:ObjectName="Truncate TransactionType_Staging"
+          DTS:TaskContact="Execute SQL Task; Microsoft Corporation; SQL Server 2016 RC2; © 2015 Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1"
+          DTS:ThreadHint="0">
+          <DTS:Variables />
+          <DTS:ObjectData>
+            <SQLTask:SqlTaskData
+              SQLTask:Connection="{7C3E3ECC-C5AD-4675-9618-FC08465F8BC9}"
+              SQLTask:SqlStatementSource="DELETE FROM Integration.TransactionType_Staging;" xmlns:SQLTask="www.microsoft.com/sqlserver/dts/tasks/sqltask" />
+          </DTS:ObjectData>
+        </DTS:Executable>
+      </DTS:Executables>
+      <DTS:PrecedenceConstraints>
+        <DTS:PrecedenceConstraint
+          DTS:refId="Package\Load Transaction Type Dimension.PrecedenceConstraints[Constraint]"
+          DTS:CreationName=""
+          DTS:DTSID="{fc206f0d-1795-4548-8fcf-591f73a89167}"
+          DTS:From="Package\Load Transaction Type Dimension\Set TableName to Transaction Type"
+          DTS:LogicalAnd="True"
+          DTS:ObjectName="Constraint"
+          DTS:To="Package\Load Transaction Type Dimension\Get Lineage Key" />
+        <DTS:PrecedenceConstraint
+          DTS:refId="Package\Load Transaction Type Dimension.PrecedenceConstraints[Constraint 1]"
+          DTS:CreationName=""
+          DTS:DTSID="{ccfee080-afc1-46c1-bf7d-1f886ba1ed36}"
+          DTS:From="Package\Load Transaction Type Dimension\Get Lineage Key"
+          DTS:LogicalAnd="True"
+          DTS:ObjectName="Constraint 1"
+          DTS:To="Package\Load Transaction Type Dimension\Truncate TransactionType_Staging" />
+        <DTS:PrecedenceConstraint
+          DTS:refId="Package\Load Transaction Type Dimension.PrecedenceConstraints[Constraint 2]"
+          DTS:CreationName=""
+          DTS:DTSID="{ef2e520e-a883-402d-9a34-4d1cf983ec81}"
+          DTS:From="Package\Load Transaction Type Dimension\Truncate TransactionType_Staging"
+          DTS:LogicalAnd="True"
+          DTS:ObjectName="Constraint 2"
+          DTS:To="Package\Load Transaction Type Dimension\Get Last Transaction Type ETL Cutoff Time" />
+        <DTS:PrecedenceConstraint
+          DTS:refId="Package\Load Transaction Type Dimension.PrecedenceConstraints[Constraint 3]"
+          DTS:CreationName=""
+          DTS:DTSID="{425488de-b8be-47b4-b218-451bb4a5edf9}"
+          DTS:From="Package\Load Transaction Type Dimension\Get Last Transaction Type ETL Cutoff Time"
+          DTS:LogicalAnd="True"
+          DTS:ObjectName="Constraint 3"
+          DTS:To="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging" />
+        <DTS:PrecedenceConstraint
+          DTS:refId="Package\Load Transaction Type Dimension.PrecedenceConstraints[Constraint 4]"
+          DTS:CreationName=""
+          DTS:DTSID="{87442ac3-b72c-42d0-8a46-c7b6b1b31b24}"
+          DTS:From="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging"
+          DTS:LogicalAnd="True"
+          DTS:ObjectName="Constraint 4"
+          DTS:To="Package\Load Transaction Type Dimension\Migrate Staged Transaction Type Data" />
+      </DTS:PrecedenceConstraints>
+    </DTS:Executable>
+    <DTS:Executable
+      DTS:refId="Package\Trim Any Milliseconds"
+      DTS:CreationName="Microsoft.ExpressionTask"
+      DTS:Description="Expression Task"
+      DTS:DTSID="{cbe59f26-38bf-4e56-bd20-37c694c38787}"
+      DTS:ExecutableType="Microsoft.ExpressionTask"
+      DTS:LocaleID="-1"
+      DTS:ObjectName="Trim Any Milliseconds"
+      DTS:TaskContact="Expression Task;Microsoft Corporation; SQL Server 2016 RC2; © 2015 Microsoft Corporation; All Rights Reserved;http://www.microsoft.com/sql/support/default.asp;1"
+      DTS:ThreadHint="0">
+      <DTS:Variables />
+      <DTS:ObjectData>
+        <ExpressionTask
+          Expression="@[User::TargetETLCutoffTime] = DATEADD(&quot;Millisecond&quot;, 0 - DATEPART(&quot;Millisecond&quot;, @[User::TargetETLCutoffTime]), @[User::TargetETLCutoffTime])" />
+      </DTS:ObjectData>
+    </DTS:Executable>
+  </DTS:Executables>
+  <DTS:PrecedenceConstraints>
+    <DTS:PrecedenceConstraint
+      DTS:refId="Package.PrecedenceConstraints[Constraint]"
+      DTS:CreationName=""
+      DTS:DTSID="{383D49BD-43D3-4E85-8E29-BACD4782DC7A}"
+      DTS:From="Package\Calculate ETL Cutoff Time backup"
+      DTS:LogicalAnd="True"
+      DTS:ObjectName="Constraint"
+      DTS:To="Package\Trim Any Milliseconds" />
+    <DTS:PrecedenceConstraint
+      DTS:refId="Package.PrecedenceConstraints[Constraint 1]"
+      DTS:CreationName=""
+      DTS:DTSID="{BFBC83C2-EC6C-4DF0-804E-ED1C71F57DC7}"
+      DTS:From="Package\Ensure Date Dimension includes current year"
+      DTS:LogicalAnd="True"
+      DTS:ObjectName="Constraint 1"
+      DTS:To="Package\Load City Dimension" />
+    <DTS:PrecedenceConstraint
+      DTS:refId="Package.PrecedenceConstraints[Constraint 10]"
+      DTS:CreationName=""
+      DTS:DTSID="{0594DF58-0479-4D58-ABF1-EDD91347DAC2}"
+      DTS:From="Package\Load Movement Fact"
+      DTS:LogicalAnd="True"
+      DTS:ObjectName="Constraint 10"
+      DTS:To="Package\Load Order Fact" />
+    <DTS:PrecedenceConstraint
+      DTS:refId="Package.PrecedenceConstraints[Constraint 11]"
+      DTS:CreationName=""
+      DTS:DTSID="{85DD5660-6F7E-490C-98C7-E97E628B3C3E}"
+      DTS:From="Package\Load Order Fact"
+      DTS:LogicalAnd="True"
+      DTS:ObjectName="Constraint 11"
+      DTS:To="Package\Load Purchase Fact" />
+    <DTS:PrecedenceConstraint
+      DTS:refId="Package.PrecedenceConstraints[Constraint 12]"
+      DTS:CreationName=""
+      DTS:DTSID="{04ECAB24-6131-4854-B3A0-5ACDAE509C99}"
+      DTS:From="Package\Load Purchase Fact"
+      DTS:LogicalAnd="True"
+      DTS:ObjectName="Constraint 12"
+      DTS:To="Package\Load Sale Fact" />
+    <DTS:PrecedenceConstraint
+      DTS:refId="Package.PrecedenceConstraints[Constraint 13]"
+      DTS:CreationName=""
+      DTS:DTSID="{D79F5902-7F6B-4D77-9763-FE60460DEC9A}"
+      DTS:From="Package\Load Sale Fact"
+      DTS:LogicalAnd="True"
+      DTS:ObjectName="Constraint 13"
+      DTS:To="Package\Load Stock Holding Fact" />
+    <DTS:PrecedenceConstraint
+      DTS:refId="Package.PrecedenceConstraints[Constraint 14]"
+      DTS:CreationName=""
+      DTS:DTSID="{FCC72957-10CD-4E93-B573-5C399BB66C77}"
+      DTS:From="Package\Load Stock Holding Fact"
+      DTS:LogicalAnd="True"
+      DTS:ObjectName="Constraint 14"
+      DTS:To="Package\Load Transaction Fact" />
+    <DTS:PrecedenceConstraint
+      DTS:refId="Package.PrecedenceConstraints[Constraint 2]"
+      DTS:CreationName=""
+      DTS:DTSID="{410117F0-A42F-4327-9459-75C990CF8075}"
+      DTS:From="Package\Trim Any Milliseconds"
+      DTS:LogicalAnd="True"
+      DTS:ObjectName="Constraint 2"
+      DTS:To="Package\Ensure Date Dimension includes current year" />
+    <DTS:PrecedenceConstraint
+      DTS:refId="Package.PrecedenceConstraints[Constraint 3]"
+      DTS:CreationName=""
+      DTS:DTSID="{46E080EC-215D-4984-BDAE-F6042F404B57}"
+      DTS:From="Package\Load City Dimension"
+      DTS:LogicalAnd="True"
+      DTS:ObjectName="Constraint 3"
+      DTS:To="Package\Load Customer Dimension" />
+    <DTS:PrecedenceConstraint
+      DTS:refId="Package.PrecedenceConstraints[Constraint 4]"
+      DTS:CreationName=""
+      DTS:DTSID="{4EC4B3F7-F383-4995-AC2F-B01E45AA8496}"
+      DTS:From="Package\Load Customer Dimension"
+      DTS:LogicalAnd="True"
+      DTS:ObjectName="Constraint 4"
+      DTS:To="Package\Load Employee Dimension" />
+    <DTS:PrecedenceConstraint
+      DTS:refId="Package.PrecedenceConstraints[Constraint 5]"
+      DTS:CreationName=""
+      DTS:DTSID="{0E770FB0-0B29-4574-9AF6-60915F829D1A}"
+      DTS:From="Package\Load Employee Dimension"
+      DTS:LogicalAnd="True"
+      DTS:ObjectName="Constraint 5"
+      DTS:To="Package\Load Payment Method Dimension" />
+    <DTS:PrecedenceConstraint
+      DTS:refId="Package.PrecedenceConstraints[Constraint 6]"
+      DTS:CreationName=""
+      DTS:DTSID="{E91AA152-CF8B-4345-9B34-73E8CFFA55EE}"
+      DTS:From="Package\Load Payment Method Dimension"
+      DTS:LogicalAnd="True"
+      DTS:ObjectName="Constraint 6"
+      DTS:To="Package\Load Stock Item Dimension" />
+    <DTS:PrecedenceConstraint
+      DTS:refId="Package.PrecedenceConstraints[Constraint 7]"
+      DTS:CreationName=""
+      DTS:DTSID="{49D25CAA-A724-4EC3-848A-BA7AA702AA14}"
+      DTS:From="Package\Load Stock Item Dimension"
+      DTS:LogicalAnd="True"
+      DTS:ObjectName="Constraint 7"
+      DTS:To="Package\Load Supplier Dimension" />
+    <DTS:PrecedenceConstraint
+      DTS:refId="Package.PrecedenceConstraints[Constraint 8]"
+      DTS:CreationName=""
+      DTS:DTSID="{5F0983D2-BB38-4028-A452-CC9ED3E5816D}"
+      DTS:From="Package\Load Supplier Dimension"
+      DTS:LogicalAnd="True"
+      DTS:ObjectName="Constraint 8"
+      DTS:To="Package\Load Transaction Type Dimension" />
+    <DTS:PrecedenceConstraint
+      DTS:refId="Package.PrecedenceConstraints[Constraint 9]"
+      DTS:CreationName=""
+      DTS:DTSID="{B61B382F-A3E8-4D62-B00C-7ADC5D41D9C0}"
+      DTS:From="Package\Load Transaction Type Dimension"
+      DTS:LogicalAnd="True"
+      DTS:ObjectName="Constraint 9"
+      DTS:To="Package\Load Movement Fact" />
+  </DTS:PrecedenceConstraints>
+  <DTS:DesignTimeProperties><![CDATA[<?xml version="1.0"?>
+<!--This CDATA section contains the layout information of the package. The section includes information such as (x,y) coordinates, width, and height.-->
+<!--If you manually edit this section and make a mistake, you can delete it. -->
+<!--The package will still be able to load normally but the previous layout information will be lost and the designer will automatically re-arrange the elements on the design surface.-->
+<Objects
+  Version="8">
+  <!--Each node below will contain properties that do not affect runtime behavior.-->
+  <Package
+    design-time-name="Package">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="256" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mssgm="clr-namespace:Microsoft.SqlServer.Graph.Model;assembly=Microsoft.SqlServer.Graph">
+        <NodeLayout
+          Size="291.2,41.6"
+          Id="Package\Calculate ETL Cutoff Time backup"
+          TopLeft="204.500000000001,149.5" />
+        <NodeLayout
+          Size="291.2,41.6"
+          Id="Package\Ensure Date Dimension includes current year"
+          TopLeft="204.500000000001,297.366666666667" />
+        <NodeLayout
+          Size="252,41.6"
+          Id="Package\Load City Dimension\Extract Updated City Data to Staging"
+          TopLeft="5.50000000000006,413.5" />
+        <NodeLayout
+          Size="217.6,41.6"
+          Id="Package\Load City Dimension\Get Last City ETL Cutoff Time"
+          TopLeft="22.5000000000001,311.5" />
+        <NodeLayout
+          Size="156,41.6"
+          Id="Package\Load City Dimension\Get Lineage Key"
+          TopLeft="53.5,107.5" />
+        <NodeLayout
+          Size="196,41.6"
+          Id="Package\Load City Dimension\Migrate Staged City Data"
+          TopLeft="33.5000000000001,515.5" />
+        <NodeLayout
+          Size="184,41.6"
+          Id="Package\Load City Dimension\Set TableName to City"
+          TopLeft="39.5,5.5" />
+        <NodeLayout
+          Size="183.2,41.6"
+          Id="Package\Load City Dimension\Truncate City_Staging"
+          TopLeft="40,209.5" />
+        <EdgeLayout
+          Id="Package\Load City Dimension.PrecedenceConstraints[Constraint]"
+          TopLeft="131.5,251.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load City Dimension.PrecedenceConstraints[Constraint 1]"
+          TopLeft="131.5,353.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load City Dimension.PrecedenceConstraints[Constraint 2]"
+          TopLeft="131.5,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load City Dimension.PrecedenceConstraints[Constraint 3]"
+          TopLeft="131.5,455.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load City Dimension.PrecedenceConstraints[Constraint 4]"
+          TopLeft="131.5,149.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <ContainerLayout
+          HeaderHeight="43"
+          IsExpanded="False"
+          PanelSize="291.2,612"
+          Size="291.2,43.2"
+          Id="Package\Load City Dimension"
+          TopLeft="204.500000000001,371.3" />
+        <NodeLayout
+          Size="279.2,41.6"
+          Id="Package\Load Customer Dimension\Extract Updated Customer Data to Staging"
+          TopLeft="5.50000000000006,413.5" />
+        <NodeLayout
+          Size="244.8,41.6"
+          Id="Package\Load Customer Dimension\Get Last Customer ETL Cutoff Time"
+          TopLeft="22.5000000000001,311.5" />
+        <NodeLayout
+          Size="156,41.6"
+          Id="Package\Load Customer Dimension\Get Lineage Key"
+          TopLeft="67,107.5" />
+        <NodeLayout
+          Size="224,41.6"
+          Id="Package\Load Customer Dimension\Migrate Staged Customer Data"
+          TopLeft="33.0000000000001,515.5" />
+        <NodeLayout
+          Size="211.2,41.6"
+          Id="Package\Load Customer Dimension\Set TableName to Customer"
+          TopLeft="39.5,5.5" />
+        <NodeLayout
+          Size="209.6,41.6"
+          Id="Package\Load Customer Dimension\Truncate Customer_Staging"
+          TopLeft="40,209.5" />
+        <EdgeLayout
+          Id="Package\Load Customer Dimension.PrecedenceConstraints[Constraint]"
+          TopLeft="145,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Customer Dimension.PrecedenceConstraints[Constraint 1]"
+          TopLeft="145,149.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Customer Dimension.PrecedenceConstraints[Constraint 2]"
+          TopLeft="145,251.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Customer Dimension.PrecedenceConstraints[Constraint 3]"
+          TopLeft="145,353.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Customer Dimension.PrecedenceConstraints[Constraint 4]"
+          TopLeft="145,455.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <ContainerLayout
+          HeaderHeight="43"
+          IsExpanded="False"
+          PanelSize="291.2,612.8"
+          Size="291.2,43.2"
+          Id="Package\Load Customer Dimension"
+          TopLeft="204.500000000001,446.233333333333" />
+        <NodeLayout
+          Size="280,41.6"
+          Id="Package\Load Employee Dimension\Extract Updated Employee Data to Staging"
+          TopLeft="5.50000000000006,413.5" />
+        <NodeLayout
+          Size="246.4,41.6"
+          Id="Package\Load Employee Dimension\Get Last Employee ETL Cutoff Time"
+          TopLeft="22.5000000000001,311.5" />
+        <NodeLayout
+          Size="156,41.6"
+          Id="Package\Load Employee Dimension\Get Lineage Key"
+          TopLeft="67.5,107.5" />
+        <NodeLayout
+          Size="224,41.6"
+          Id="Package\Load Employee Dimension\Migrate Staged Employee Data"
+          TopLeft="33.5000000000001,515.5" />
+        <NodeLayout
+          Size="212,41.6"
+          Id="Package\Load Employee Dimension\Set TableName to Employee"
+          TopLeft="39.5,5.5" />
+        <NodeLayout
+          Size="211.2,41.6"
+          Id="Package\Load Employee Dimension\Truncate Employee_Staging"
+          TopLeft="40,209.5" />
+        <EdgeLayout
+          Id="Package\Load Employee Dimension.PrecedenceConstraints[Constraint]"
+          TopLeft="145.5,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Employee Dimension.PrecedenceConstraints[Constraint 1]"
+          TopLeft="145.5,149.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Employee Dimension.PrecedenceConstraints[Constraint 2]"
+          TopLeft="145.5,251.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Employee Dimension.PrecedenceConstraints[Constraint 3]"
+          TopLeft="145.5,353.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Employee Dimension.PrecedenceConstraints[Constraint 4]"
+          TopLeft="145.5,455.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <ContainerLayout
+          HeaderHeight="43"
+          IsExpanded="False"
+          PanelSize="291.2,612.8"
+          Size="226.4,43.2"
+          Id="Package\Load Employee Dimension"
+          TopLeft="204.500000000001,521.166666666667" />
+        <NodeLayout
+          Size="284,42"
+          Id="Package\Load Movement Fact\Extract Updated Movement Data to Staging"
+          TopLeft="5.50000000000006,413.5" />
+        <NodeLayout
+          Size="249,42"
+          Id="Package\Load Movement Fact\Get Last Movement ETL Cutoff Time"
+          TopLeft="23.0000000000001,311.5" />
+        <NodeLayout
+          Size="156,42"
+          Id="Package\Load Movement Fact\Get Lineage Key"
+          TopLeft="69.5,107.5" />
+        <NodeLayout
+          Size="228,42"
+          Id="Package\Load Movement Fact\Migrate Staged Movement Data"
+          TopLeft="33.5000000000001,515.5" />
+        <NodeLayout
+          Size="216,42"
+          Id="Package\Load Movement Fact\Set TableName to Movement"
+          TopLeft="39.5,5.5" />
+        <NodeLayout
+          Size="214,42"
+          Id="Package\Load Movement Fact\Truncate Movement_Staging"
+          TopLeft="40.5,209.5" />
+        <EdgeLayout
+          Id="Package\Load Movement Fact.PrecedenceConstraints[Constraint]"
+          TopLeft="147.5,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Movement Fact.PrecedenceConstraints[Constraint 1]"
+          TopLeft="147.5,149.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Movement Fact.PrecedenceConstraints[Constraint 2]"
+          TopLeft="147.5,251.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Movement Fact.PrecedenceConstraints[Constraint 3]"
+          TopLeft="147.5,353.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Movement Fact.PrecedenceConstraints[Constraint 4]"
+          TopLeft="147.5,455.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <ContainerLayout
+          HeaderHeight="43"
+          IsExpanded="False"
+          PanelSize="295,613"
+          Size="291.2,43.2"
+          Id="Package\Load Movement Fact"
+          TopLeft="204.500000000001,895.833333333333" />
+        <NodeLayout
+          Size="261,42"
+          Id="Package\Load Order Fact\Extract Updated Order Data to Staging"
+          TopLeft="5.50000000000006,413.5" />
+        <NodeLayout
+          Size="249,42"
+          Id="Package\Load Order Fact\Get Last Movement ETL Cutoff Time"
+          TopLeft="11.5000000000001,311.5" />
+        <NodeLayout
+          Size="156,42"
+          Id="Package\Load Order Fact\Get Lineage Key"
+          TopLeft="58,107.5" />
+        <NodeLayout
+          Size="205,42"
+          Id="Package\Load Order Fact\Migrate Staged Order Data"
+          TopLeft="33.5000000000001,515.5" />
+        <NodeLayout
+          Size="193,42"
+          Id="Package\Load Order Fact\Set TableName to Order"
+          TopLeft="39.5,5.5" />
+        <NodeLayout
+          Size="192,42"
+          Id="Package\Load Order Fact\Truncate Order_Staging"
+          TopLeft="40,209.5" />
+        <EdgeLayout
+          Id="Package\Load Order Fact.PrecedenceConstraints[Constraint]"
+          TopLeft="136,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Order Fact.PrecedenceConstraints[Constraint 1]"
+          TopLeft="136,149.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Order Fact.PrecedenceConstraints[Constraint 2]"
+          TopLeft="136,251.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Order Fact.PrecedenceConstraints[Constraint 3]"
+          TopLeft="136,353.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Order Fact.PrecedenceConstraints[Constraint 4]"
+          TopLeft="136,455.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <ContainerLayout
+          HeaderHeight="43"
+          IsExpanded="False"
+          PanelSize="291,613"
+          Size="291.2,43.2"
+          Id="Package\Load Order Fact"
+          TopLeft="204.500000000001,970.766666666666" />
+        <NodeLayout
+          Size="314,42"
+          Id="Package\Load Payment Method Dimension\Extract Updated Payment Method Data to Staging"
+          TopLeft="5.50000000000006,413.5" />
+        <NodeLayout
+          Size="280,42"
+          Id="Package\Load Payment Method Dimension\Get Last Payment Method ETL Cutoff Time"
+          TopLeft="22.5000000000001,311.5" />
+        <NodeLayout
+          Size="156,42"
+          Id="Package\Load Payment Method Dimension\Get Lineage Key"
+          TopLeft="84.5,107.5" />
+        <NodeLayout
+          Size="258,42"
+          Id="Package\Load Payment Method Dimension\Migrate Staged Payment Method Data"
+          TopLeft="33.5000000000001,515.5" />
+        <NodeLayout
+          Size="246,42"
+          Id="Package\Load Payment Method Dimension\Set TableName to Payment Method"
+          TopLeft="39.5,5.5" />
+        <NodeLayout
+          Size="241,42"
+          Id="Package\Load Payment Method Dimension\Truncate PaymentMethod_Staging"
+          TopLeft="42,209.5" />
+        <EdgeLayout
+          Id="Package\Load Payment Method Dimension.PrecedenceConstraints[Constraint]"
+          TopLeft="162.5,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Payment Method Dimension.PrecedenceConstraints[Constraint 1]"
+          TopLeft="162.5,149.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Payment Method Dimension.PrecedenceConstraints[Constraint 2]"
+          TopLeft="162.5,251.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Payment Method Dimension.PrecedenceConstraints[Constraint 3]"
+          TopLeft="162.5,353.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Payment Method Dimension.PrecedenceConstraints[Constraint 4]"
+          TopLeft="162.5,455.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <ContainerLayout
+          HeaderHeight="43"
+          IsExpanded="False"
+          PanelSize="325,613"
+          Size="291.2,43.2"
+          Id="Package\Load Payment Method Dimension"
+          TopLeft="204.500000000001,596.1" />
+        <NodeLayout
+          Size="276.8,41.6"
+          Id="Package\Load Purchase Fact\Extract Updated Purchase Data to Staging"
+          TopLeft="5.50000000000006,413.5" />
+        <NodeLayout
+          Size="248.8,41.6"
+          Id="Package\Load Purchase Fact\Get Last Movement ETL Cutoff Time"
+          TopLeft="19.5000000000001,311.5" />
+        <NodeLayout
+          Size="156,41.6"
+          Id="Package\Load Purchase Fact\Get Lineage Key"
+          TopLeft="66,107.5" />
+        <NodeLayout
+          Size="220.8,41.6"
+          Id="Package\Load Purchase Fact\Migrate Staged Purchase Data"
+          TopLeft="33.5000000000001,515.5" />
+        <NodeLayout
+          Size="208.8,41.6"
+          Id="Package\Load Purchase Fact\Set TableName to Purchase"
+          TopLeft="39.5,5.5" />
+        <NodeLayout
+          Size="208,41.6"
+          Id="Package\Load Purchase Fact\Truncate Purchase_Staging"
+          TopLeft="40,209.5" />
+        <EdgeLayout
+          Id="Package\Load Purchase Fact.PrecedenceConstraints[Constraint]"
+          TopLeft="144,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Purchase Fact.PrecedenceConstraints[Constraint 1]"
+          TopLeft="144,149.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Purchase Fact.PrecedenceConstraints[Constraint 2]"
+          TopLeft="144,251.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Purchase Fact.PrecedenceConstraints[Constraint 3]"
+          TopLeft="144,353.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Purchase Fact.PrecedenceConstraints[Constraint 4]"
+          TopLeft="144,455.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <ContainerLayout
+          HeaderHeight="43"
+          IsExpanded="False"
+          PanelSize="291.2,612.8"
+          Size="291.2,43.2"
+          Id="Package\Load Purchase Fact"
+          TopLeft="204.500000000001,1045.7" />
+        <NodeLayout
+          Size="254.4,41.6"
+          Id="Package\Load Sale Fact\Extract Updated Sale Data to Staging"
+          TopLeft="5.50000000000006,413.5" />
+        <NodeLayout
+          Size="248.8,41.6"
+          Id="Package\Load Sale Fact\Get Last Movement ETL Cutoff Time"
+          TopLeft="8.00000000000006,311.5" />
+        <NodeLayout
+          Size="156,41.6"
+          Id="Package\Load Sale Fact\Get Lineage Key"
+          TopLeft="54.5,107.5" />
+        <NodeLayout
+          Size="198.4,41.6"
+          Id="Package\Load Sale Fact\Migrate Staged Sale Data"
+          TopLeft="33.5000000000001,515.5" />
+        <NodeLayout
+          Size="185.6,41.6"
+          Id="Package\Load Sale Fact\Set TableName to Sale"
+          TopLeft="39.5,5.5" />
+        <NodeLayout
+          Size="184.8,41.6"
+          Id="Package\Load Sale Fact\Truncate Sale_Staging"
+          TopLeft="40,209.5" />
+        <EdgeLayout
+          Id="Package\Load Sale Fact.PrecedenceConstraints[Constraint]"
+          TopLeft="132.5,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Sale Fact.PrecedenceConstraints[Constraint 1]"
+          TopLeft="132.5,149.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Sale Fact.PrecedenceConstraints[Constraint 2]"
+          TopLeft="132.5,251.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Sale Fact.PrecedenceConstraints[Constraint 3]"
+          TopLeft="132.5,353.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Sale Fact.PrecedenceConstraints[Constraint 4]"
+          TopLeft="132.5,455.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <ContainerLayout
+          HeaderHeight="43"
+          IsExpanded="False"
+          PanelSize="291.2,612.8"
+          Size="172,43.2"
+          Id="Package\Load Sale Fact"
+          TopLeft="204.500000000001,1120.63333333333" />
+        <NodeLayout
+          Size="271,42"
+          Id="Package\Load Stock Holding Fact\Extract All Stock Holding Data to Staging"
+          TopLeft="5.50000000000006,413.5" />
+        <NodeLayout
+          Size="249,42"
+          Id="Package\Load Stock Holding Fact\Get Last Movement ETL Cutoff Time"
+          TopLeft="16.5000000000001,311.5" />
+        <NodeLayout
+          Size="156,42"
+          Id="Package\Load Stock Holding Fact\Get Lineage Key"
+          TopLeft="63,107.5" />
+        <NodeLayout
+          Size="243,42"
+          Id="Package\Load Stock Holding Fact\Migrate Staged Stock Holding Data"
+          TopLeft="19.5000000000001,515.5" />
+        <NodeLayout
+          Size="231,42"
+          Id="Package\Load Stock Holding Fact\Set TableName to Stock Holding"
+          TopLeft="25.5,5.5" />
+        <NodeLayout
+          Size="226,42"
+          Id="Package\Load Stock Holding Fact\Truncate StockHolding_Staging"
+          TopLeft="28,209.5" />
+        <EdgeLayout
+          Id="Package\Load Stock Holding Fact.PrecedenceConstraints[Constraint]"
+          TopLeft="141,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Stock Holding Fact.PrecedenceConstraints[Constraint 1]"
+          TopLeft="141,149.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Stock Holding Fact.PrecedenceConstraints[Constraint 2]"
+          TopLeft="141,251.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Stock Holding Fact.PrecedenceConstraints[Constraint 3]"
+          TopLeft="141,353.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Stock Holding Fact.PrecedenceConstraints[Constraint 4]"
+          TopLeft="141,455.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <ContainerLayout
+          HeaderHeight="43"
+          IsExpanded="False"
+          PanelSize="291,613"
+          Size="291.2,43.2"
+          Id="Package\Load Stock Holding Fact"
+          TopLeft="204.500000000001,1195.56666666667" />
+        <NodeLayout
+          Size="286,42"
+          Id="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging"
+          TopLeft="5.50000000000006,413.5" />
+        <NodeLayout
+          Size="251,42"
+          Id="Package\Load Stock Item Dimension\Get Last Stock Item ETL Cutoff Time"
+          TopLeft="23.0000000000001,311.5" />
+        <NodeLayout
+          Size="156,42"
+          Id="Package\Load Stock Item Dimension\Get Lineage Key"
+          TopLeft="70.5,107.5" />
+        <NodeLayout
+          Size="230,42"
+          Id="Package\Load Stock Item Dimension\Migrate Staged Stock Item Data"
+          TopLeft="33.5000000000001,515.5" />
+        <NodeLayout
+          Size="218,42"
+          Id="Package\Load Stock Item Dimension\Set TableName to Stock Item"
+          TopLeft="39.5,5.5" />
+        <NodeLayout
+          Size="213,42"
+          Id="Package\Load Stock Item Dimension\Truncate StockItem_Staging"
+          TopLeft="42,209.5" />
+        <EdgeLayout
+          Id="Package\Load Stock Item Dimension.PrecedenceConstraints[Constraint]"
+          TopLeft="148.5,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Stock Item Dimension.PrecedenceConstraints[Constraint 1]"
+          TopLeft="148.5,149.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Stock Item Dimension.PrecedenceConstraints[Constraint 2]"
+          TopLeft="148.5,251.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Stock Item Dimension.PrecedenceConstraints[Constraint 3]"
+          TopLeft="148.5,353.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Stock Item Dimension.PrecedenceConstraints[Constraint 4]"
+          TopLeft="148.5,455.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <ContainerLayout
+          HeaderHeight="43"
+          IsExpanded="False"
+          PanelSize="297,613"
+          Size="291.2,43.2"
+          Id="Package\Load Stock Item Dimension"
+          TopLeft="204.500000000001,671.033333333333" />
+        <NodeLayout
+          Size="273,42"
+          Id="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging"
+          TopLeft="5.50000000000006,413.5" />
+        <NodeLayout
+          Size="238,42"
+          Id="Package\Load Supplier Dimension\Get Last Supplier ETL Cutoff Time"
+          TopLeft="23.0000000000001,311.5" />
+        <NodeLayout
+          Size="156,42"
+          Id="Package\Load Supplier Dimension\Get Lineage Key"
+          TopLeft="64,107.5" />
+        <NodeLayout
+          Size="217,42"
+          Id="Package\Load Supplier Dimension\Migrate Staged Supplier Data"
+          TopLeft="33.5000000000001,515.5" />
+        <NodeLayout
+          Size="205,42"
+          Id="Package\Load Supplier Dimension\Set TableName to Supplier"
+          TopLeft="39.5,5.5" />
+        <NodeLayout
+          Size="203,42"
+          Id="Package\Load Supplier Dimension\Truncate Supplier_Staging"
+          TopLeft="40.5,209.5" />
+        <EdgeLayout
+          Id="Package\Load Supplier Dimension.PrecedenceConstraints[Constraint]"
+          TopLeft="142,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Supplier Dimension.PrecedenceConstraints[Constraint 1]"
+          TopLeft="142,149.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Supplier Dimension.PrecedenceConstraints[Constraint 2]"
+          TopLeft="142,251.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Supplier Dimension.PrecedenceConstraints[Constraint 3]"
+          TopLeft="142,353.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Supplier Dimension.PrecedenceConstraints[Constraint 4]"
+          TopLeft="142,455.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <ContainerLayout
+          HeaderHeight="43"
+          IsExpanded="False"
+          PanelSize="291,613"
+          Size="291.2,43.2"
+          Id="Package\Load Supplier Dimension"
+          TopLeft="204.500000000001,745.966666666666" />
+        <NodeLayout
+          Size="289,42"
+          Id="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging"
+          TopLeft="5.50000000000006,413.5" />
+        <NodeLayout
+          Size="249,42"
+          Id="Package\Load Transaction Fact\Get Last Movement ETL Cutoff Time"
+          TopLeft="25.5000000000001,311.5" />
+        <NodeLayout
+          Size="156,42"
+          Id="Package\Load Transaction Fact\Get Lineage Key"
+          TopLeft="72,107.5" />
+        <NodeLayout
+          Size="233,42"
+          Id="Package\Load Transaction Fact\Migrate Staged Transaction Data"
+          TopLeft="33.5000000000001,515.5" />
+        <NodeLayout
+          Size="221,42"
+          Id="Package\Load Transaction Fact\Set TableName to Transaction"
+          TopLeft="39.5,5.5" />
+        <NodeLayout
+          Size="220,42"
+          Id="Package\Load Transaction Fact\Truncate Transaction_Staging"
+          TopLeft="40,209.5" />
+        <EdgeLayout
+          Id="Package\Load Transaction Fact.PrecedenceConstraints[Constraint]"
+          TopLeft="150,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Transaction Fact.PrecedenceConstraints[Constraint 1]"
+          TopLeft="150,149.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Transaction Fact.PrecedenceConstraints[Constraint 2]"
+          TopLeft="150,251.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Transaction Fact.PrecedenceConstraints[Constraint 3]"
+          TopLeft="150,353.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Transaction Fact.PrecedenceConstraints[Constraint 4]"
+          TopLeft="150,455.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <ContainerLayout
+          HeaderHeight="43"
+          IsExpanded="False"
+          PanelSize="300,613"
+          Size="291.2,43.2"
+          Id="Package\Load Transaction Fact"
+          TopLeft="204.500000000001,1270.5" />
+        <NodeLayout
+          Size="316,42"
+          Id="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging"
+          TopLeft="5.50000000000006,413.5" />
+        <NodeLayout
+          Size="281,42"
+          Id="Package\Load Transaction Type Dimension\Get Last Transaction Type ETL Cutoff Time"
+          TopLeft="23.0000000000001,311.5" />
+        <NodeLayout
+          Size="156,42"
+          Id="Package\Load Transaction Type Dimension\Get Lineage Key"
+          TopLeft="85.5,107.5" />
+        <NodeLayout
+          Size="260,42"
+          Id="Package\Load Transaction Type Dimension\Migrate Staged Transaction Type Data"
+          TopLeft="33.5000000000001,515.5" />
+        <NodeLayout
+          Size="248,42"
+          Id="Package\Load Transaction Type Dimension\Set TableName to Transaction Type"
+          TopLeft="39.5,5.5" />
+        <NodeLayout
+          Size="243,42"
+          Id="Package\Load Transaction Type Dimension\Truncate TransactionType_Staging"
+          TopLeft="42,209.5" />
+        <EdgeLayout
+          Id="Package\Load Transaction Type Dimension.PrecedenceConstraints[Constraint]"
+          TopLeft="163.5,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Transaction Type Dimension.PrecedenceConstraints[Constraint 1]"
+          TopLeft="163.5,149.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Transaction Type Dimension.PrecedenceConstraints[Constraint 2]"
+          TopLeft="163.5,251.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Transaction Type Dimension.PrecedenceConstraints[Constraint 3]"
+          TopLeft="163.5,353.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package\Load Transaction Type Dimension.PrecedenceConstraints[Constraint 4]"
+          TopLeft="163.5,455.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <ContainerLayout
+          HeaderHeight="43"
+          IsExpanded="False"
+          PanelSize="327,613"
+          Size="291.2,43.2"
+          Id="Package\Load Transaction Type Dimension"
+          TopLeft="204.500000000001,820.9" />
+        <NodeLayout
+          Size="291.2,41.6"
+          Id="Package\Trim Any Milliseconds"
+          TopLeft="204.500000000001,223.433333333333" />
+        <EdgeLayout
+          Id="Package.PrecedenceConstraints[Constraint]"
+          TopLeft="350.000000000001,191.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,31.9333333333333"
+              Start="0,0"
+              End="0,24.4333333333333">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,24.4333333333333" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package.PrecedenceConstraints[Constraint 1]"
+          TopLeft="350.100000000001,338.966666666667">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,32.333333333333"
+              Start="0,0"
+              End="0,24.833333333333">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,24.833333333333" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package.PrecedenceConstraints[Constraint 10]"
+          TopLeft="350.000000000001,938.833333333333">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,31.9333333333333"
+              Start="0,0"
+              End="0,24.4333333333333">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,24.4333333333333" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package.PrecedenceConstraints[Constraint 11]"
+          TopLeft="350.100000000001,1013.96666666667">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,31.733333333334"
+              Start="0,0"
+              End="0,24.233333333334">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,24.233333333334" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package.PrecedenceConstraints[Constraint 12]"
+          TopLeft="350.100000000001,1088.9">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="-59.5999999999999,31.7333333333299"
+              Start="0,0"
+              End="-59.5999999999999,24.2333333333299">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,11.866666666665" />
+                  <mssgle:CubicBezierSegment
+                    Point1="0,11.866666666665"
+                    Point2="0,15.866666666665"
+                    Point3="-4,15.866666666665" />
+                  <mssgle:LineSegment
+                    End="-55.5999999999999,15.866666666665" />
+                  <mssgle:CubicBezierSegment
+                    Point1="-55.5999999999999,15.866666666665"
+                    Point2="-59.5999999999999,15.866666666665"
+                    Point3="-59.5999999999999,19.866666666665" />
+                  <mssgle:LineSegment
+                    End="-59.5999999999999,24.2333333333299" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package.PrecedenceConstraints[Constraint 13]"
+          TopLeft="290.500000000001,1163.83333333333">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="59.6,31.7333333333399"
+              Start="0,0"
+              End="59.6,24.2333333333399">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,11.86666666667" />
+                  <mssgle:CubicBezierSegment
+                    Point1="0,11.86666666667"
+                    Point2="0,15.86666666667"
+                    Point3="4,15.86666666667" />
+                  <mssgle:LineSegment
+                    End="55.6,15.86666666667" />
+                  <mssgle:CubicBezierSegment
+                    Point1="55.6,15.86666666667"
+                    Point2="59.6,15.86666666667"
+                    Point3="59.6,19.86666666667" />
+                  <mssgle:LineSegment
+                    End="59.6,24.2333333333399" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package.PrecedenceConstraints[Constraint 14]"
+          TopLeft="350.000000000001,1238.56666666667">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,31.9333333333334"
+              Start="0,0"
+              End="0,24.4333333333334">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,24.4333333333334" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package.PrecedenceConstraints[Constraint 2]"
+          TopLeft="350.000000000001,265.433333333333">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,31.9333333333333"
+              Start="0,0"
+              End="0,24.4333333333333">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,24.4333333333333" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package.PrecedenceConstraints[Constraint 3]"
+          TopLeft="350.100000000001,414.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,31.733333333333"
+              Start="0,0"
+              End="0,24.233333333333">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,24.233333333333" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package.PrecedenceConstraints[Constraint 4]"
+          TopLeft="350.100000000001,489.433333333333">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="-32.3999999999999,31.733333333334"
+              Start="0,0"
+              End="-32.3999999999999,24.233333333334">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,11.866666666667" />
+                  <mssgle:CubicBezierSegment
+                    Point1="0,11.866666666667"
+                    Point2="0,15.866666666667"
+                    Point3="-4,15.866666666667" />
+                  <mssgle:LineSegment
+                    End="-28.3999999999999,15.866666666667" />
+                  <mssgle:CubicBezierSegment
+                    Point1="-28.3999999999999,15.866666666667"
+                    Point2="-32.3999999999999,15.866666666667"
+                    Point3="-32.3999999999999,19.866666666667" />
+                  <mssgle:LineSegment
+                    End="-32.3999999999999,24.233333333334" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package.PrecedenceConstraints[Constraint 5]"
+          TopLeft="317.700000000001,564.366666666667">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="32.4,31.733333333333"
+              Start="0,0"
+              End="32.4,24.233333333333">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,11.8666666666665" />
+                  <mssgle:CubicBezierSegment
+                    Point1="0,11.8666666666665"
+                    Point2="0,15.8666666666665"
+                    Point3="4,15.8666666666665" />
+                  <mssgle:LineSegment
+                    End="28.4,15.8666666666665" />
+                  <mssgle:CubicBezierSegment
+                    Point1="28.4,15.8666666666665"
+                    Point2="32.4,15.8666666666665"
+                    Point3="32.4,19.8666666666665" />
+                  <mssgle:LineSegment
+                    End="32.4,24.233333333333" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package.PrecedenceConstraints[Constraint 6]"
+          TopLeft="350.000000000001,639.1">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,31.9333333333333"
+              Start="0,0"
+              End="0,24.4333333333333">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,24.4333333333333" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package.PrecedenceConstraints[Constraint 7]"
+          TopLeft="350.000000000001,714.033333333333">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,31.9333333333333"
+              Start="0,0"
+              End="0,24.4333333333333">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,24.4333333333333" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package.PrecedenceConstraints[Constraint 8]"
+          TopLeft="350.000000000001,788.966666666666">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,31.9333333333333"
+              Start="0,0"
+              End="0,24.4333333333333">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,24.4333333333333" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+        <EdgeLayout
+          Id="Package.PrecedenceConstraints[Constraint 9]"
+          TopLeft="350.000000000001,863.9">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,31.9333333333333"
+              Start="0,0"
+              End="0,24.4333333333333">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,24.4333333333333" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </Package>
+  <TaskHost
+    design-time-name="Package\Load City Dimension\Extract Updated City Data to Staging">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="4" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml">
+        <NodeLayout
+          Size="208.8,41.6"
+          Id="Package\Load City Dimension\Extract Updated City Data to Staging\Integration_GetCityUpdates"
+          TopLeft="5.50000000000001,5.5" />
+        <NodeLayout
+          Size="196,41.6"
+          Id="Package\Load City Dimension\Extract Updated City Data to Staging\Integration_City_Staging"
+          TopLeft="12,107.5" />
+        <EdgeLayout
+          Id="Package\Load City Dimension\Extract Updated City Data to Staging.Paths[OLE DB Source Output]"
+          TopLeft="110,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Load City Dimension\Extract Updated City Data to Staging\Integration_City_Staging">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+      <Property>
+        <Name>TableInfoObjectType</Name>
+        <Value
+          type="q2:string">Table</Value>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <TaskHost
+    design-time-name="Package\Load Customer Dimension\Extract Updated Customer Data to Staging">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="4" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mssgm="clr-namespace:Microsoft.SqlServer.Graph.Model;assembly=Microsoft.SqlServer.Graph">
+        <NodeLayout
+          Size="237,42"
+          Id="Package\Load Customer Dimension\Extract Updated Customer Data to Staging\Integration_GetCustomerUpdates"
+          TopLeft="5.50000000000001,5.5" />
+        <NodeLayout
+          Size="223,42"
+          Id="Package\Load Customer Dimension\Extract Updated Customer Data to Staging\Integration_Customer_Staging"
+          TopLeft="12.5,107.5" />
+        <EdgeLayout
+          Id="Package\Load Customer Dimension\Extract Updated Customer Data to Staging.Paths[OLE DB Source Output]"
+          TopLeft="124,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Load Customer Dimension\Extract Updated Customer Data to Staging\Integration_Customer_Staging">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+      <Property>
+        <Name>TableInfoObjectType</Name>
+        <Value
+          type="q2:string">Table</Value>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <TaskHost
+    design-time-name="Package\Load Employee Dimension\Extract Updated Employee Data to Staging">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="4" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mssgm="clr-namespace:Microsoft.SqlServer.Graph.Model;assembly=Microsoft.SqlServer.Graph">
+        <NodeLayout
+          Size="237,42"
+          Id="Package\Load Employee Dimension\Extract Updated Employee Data to Staging\Integration_GetEmployeeUpdates"
+          TopLeft="5.50000000000001,5.5" />
+        <NodeLayout
+          Size="224,42"
+          Id="Package\Load Employee Dimension\Extract Updated Employee Data to Staging\Integration_Employee_Staging"
+          TopLeft="12,107.5" />
+        <EdgeLayout
+          Id="Package\Load Employee Dimension\Extract Updated Employee Data to Staging.Paths[OLE DB Source Output]"
+          TopLeft="124,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Load Employee Dimension\Extract Updated Employee Data to Staging\Integration_Employee_Staging">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+      <Property>
+        <Name>TableInfoObjectType</Name>
+        <Value
+          type="q2:string">Table</Value>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <TaskHost
+    design-time-name="Package\Load Movement Fact\Extract Updated Movement Data to Staging">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="4" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mssgm="clr-namespace:Microsoft.SqlServer.Graph.Model;assembly=Microsoft.SqlServer.Graph">
+        <NodeLayout
+          Size="227,42"
+          Id="Package\Load Movement Fact\Extract Updated Movement Data to Staging\Integration_Movement_Staging"
+          TopLeft="12.5,107.5" />
+        <NodeLayout
+          Size="241,42"
+          Id="Package\Load Movement Fact\Extract Updated Movement Data to Staging\Integration_GetMovementUpdates"
+          TopLeft="5.50000000000001,5.5" />
+        <EdgeLayout
+          Id="Package\Load Movement Fact\Extract Updated Movement Data to Staging.Paths[OLE DB Source Output]"
+          TopLeft="126,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Load Movement Fact\Extract Updated Movement Data to Staging\Integration_Movement_Staging">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+      <Property>
+        <Name>TableInfoObjectType</Name>
+        <Value
+          type="q2:string">Table</Value>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <TaskHost
+    design-time-name="Package\Load Order Fact\Extract Updated Order Data to Staging">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="4" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mssgm="clr-namespace:Microsoft.SqlServer.Graph.Model;assembly=Microsoft.SqlServer.Graph">
+        <NodeLayout
+          Size="218,42"
+          Id="Package\Load Order Fact\Extract Updated Order Data to Staging\Integration_GetOrderUpdates"
+          TopLeft="5.50000000000001,5.5" />
+        <NodeLayout
+          Size="205,42"
+          Id="Package\Load Order Fact\Extract Updated Order Data to Staging\Integration_Order_Staging"
+          TopLeft="12,107.5" />
+        <EdgeLayout
+          Id="Package\Load Order Fact\Extract Updated Order Data to Staging.Paths[OLE DB Source Output]"
+          TopLeft="114.5,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Load Order Fact\Extract Updated Order Data to Staging\Integration_Order_Staging">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+      <Property>
+        <Name>TableInfoObjectType</Name>
+        <Value
+          type="q2:string">Table</Value>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <TaskHost
+    design-time-name="Package\Load Payment Method Dimension\Extract Updated Payment Method Data to Staging">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="4" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mssgm="clr-namespace:Microsoft.SqlServer.Graph.Model;assembly=Microsoft.SqlServer.Graph">
+        <NodeLayout
+          Size="268,42"
+          Id="Package\Load Payment Method Dimension\Extract Updated Payment Method Data to Staging\Integration_GetPaymentMethodUpdates"
+          TopLeft="5.5,5.5" />
+        <NodeLayout
+          Size="254,42"
+          Id="Package\Load Payment Method Dimension\Extract Updated Payment Method Data to Staging\Integration_PaymentMethod_Staging"
+          TopLeft="12.5,107.5" />
+        <EdgeLayout
+          Id="Package\Load Payment Method Dimension\Extract Updated Payment Method Data to Staging.Paths[OLE DB Source Output]"
+          TopLeft="139.5,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Load Payment Method Dimension\Extract Updated Payment Method Data to Staging\Integration_PaymentMethod_Staging">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+      <Property>
+        <Name>TableInfoObjectType</Name>
+        <Value
+          type="q2:string">Table</Value>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <TaskHost
+    design-time-name="Package\Load Purchase Fact\Extract Updated Purchase Data to Staging">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="4" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mssgm="clr-namespace:Microsoft.SqlServer.Graph.Model;assembly=Microsoft.SqlServer.Graph">
+        <NodeLayout
+          Size="221,42"
+          Id="Package\Load Purchase Fact\Extract Updated Purchase Data to Staging\Integration_Purchase_Staging"
+          TopLeft="12,107.5" />
+        <NodeLayout
+          Size="234,42"
+          Id="Package\Load Purchase Fact\Extract Updated Purchase Data to Staging\Integration_GetPurchaseUpdates"
+          TopLeft="5.50000000000001,5.5" />
+        <EdgeLayout
+          Id="Package\Load Purchase Fact\Extract Updated Purchase Data to Staging.Paths[OLE DB Source Output]"
+          TopLeft="122.5,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Load Purchase Fact\Extract Updated Purchase Data to Staging\Integration_Purchase_Staging">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+      <Property>
+        <Name>TableInfoObjectType</Name>
+        <Value
+          type="q2:string">Table</Value>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <TaskHost
+    design-time-name="Package\Load Sale Fact\Extract Updated Sale Data to Staging">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="4" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml">
+        <NodeLayout
+          Size="211.2,41.6"
+          Id="Package\Load Sale Fact\Extract Updated Sale Data to Staging\Integration_GetSaleUpdates"
+          TopLeft="5.50000000000001,5.5" />
+        <NodeLayout
+          Size="198.4,41.6"
+          Id="Package\Load Sale Fact\Extract Updated Sale Data to Staging\Integration_Sale_Staging"
+          TopLeft="12,107.5" />
+        <EdgeLayout
+          Id="Package\Load Sale Fact\Extract Updated Sale Data to Staging.Paths[OLE DB Source Output]"
+          TopLeft="111,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <EdgeLabelCollection />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Load Sale Fact\Extract Updated Sale Data to Staging\Integration_Sale_Staging">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+      <Property>
+        <Name>TableInfoObjectType</Name>
+        <Value
+          type="q2:string">Table</Value>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <TaskHost
+    design-time-name="Package\Load Stock Holding Fact\Extract All Stock Holding Data to Staging">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="4" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mssgm="clr-namespace:Microsoft.SqlServer.Graph.Model;assembly=Microsoft.SqlServer.Graph">
+        <NodeLayout
+          Size="239,42"
+          Id="Package\Load Stock Holding Fact\Extract All Stock Holding Data to Staging\Integration_StockHolding_Staging"
+          TopLeft="12.5,107.5" />
+        <NodeLayout
+          Size="253,42"
+          Id="Package\Load Stock Holding Fact\Extract All Stock Holding Data to Staging\Integration_GetStockHoldingUpdates"
+          TopLeft="5.5,5.5" />
+        <EdgeLayout
+          Id="Package\Load Stock Holding Fact\Extract All Stock Holding Data to Staging.Paths[OLE DB Source Output]"
+          TopLeft="132,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Load Stock Holding Fact\Extract All Stock Holding Data to Staging\Integration_StockHolding_Staging">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+      <Property>
+        <Name>TableInfoObjectType</Name>
+        <Value
+          type="q2:string">Table</Value>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <TaskHost
+    design-time-name="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="4" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mssgm="clr-namespace:Microsoft.SqlServer.Graph.Model;assembly=Microsoft.SqlServer.Graph">
+        <NodeLayout
+          Size="239,42"
+          Id="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_GetStockItemUpdates"
+          TopLeft="5.50000000000001,5.5" />
+        <NodeLayout
+          Size="226,42"
+          Id="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging"
+          TopLeft="12,107.5" />
+        <EdgeLayout
+          Id="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging.Paths[OLE DB Source Output]"
+          TopLeft="125,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Load Stock Item Dimension\Extract Updated Stock Item Data to Staging\Integration_StockItem_Staging">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+      <Property>
+        <Name>TableInfoObjectType</Name>
+        <Value
+          type="q2:string">Table</Value>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <TaskHost
+    design-time-name="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="4" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mssgm="clr-namespace:Microsoft.SqlServer.Graph.Model;assembly=Microsoft.SqlServer.Graph">
+        <NodeLayout
+          Size="216,42"
+          Id="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging"
+          TopLeft="12.5,107.5" />
+        <NodeLayout
+          Size="230,42"
+          Id="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_GetSupplierUpdates"
+          TopLeft="5.50000000000001,5.5" />
+        <EdgeLayout
+          Id="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging.Paths[OLE DB Source Output]"
+          TopLeft="120.5,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Load Supplier Dimension\Extract Updated Supplier Data to Staging\Integration_Supplier_Staging">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+      <Property>
+        <Name>TableInfoObjectType</Name>
+        <Value
+          type="q2:string">Table</Value>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <TaskHost
+    design-time-name="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="4" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mssgm="clr-namespace:Microsoft.SqlServer.Graph.Model;assembly=Microsoft.SqlServer.Graph">
+        <NodeLayout
+          Size="233,42"
+          Id="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging"
+          TopLeft="12,107.5" />
+        <NodeLayout
+          Size="246,42"
+          Id="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_GetTransactionUpdates"
+          TopLeft="5.5,5.5" />
+        <EdgeLayout
+          Id="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging.Paths[OLE DB Source Output]"
+          TopLeft="128.5,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Load Transaction Fact\Extract Updated Transaction Data to Staging\Integration_Transaction_Staging">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+      <Property>
+        <Name>TableInfoObjectType</Name>
+        <Value
+          type="q2:string">Table</Value>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+  <TaskHost
+    design-time-name="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging">
+    <LayoutInfo>
+      <GraphLayout
+        Capacity="4" xmlns="clr-namespace:Microsoft.SqlServer.IntegrationServices.Designer.Model.Serialization;assembly=Microsoft.SqlServer.IntegrationServices.Graph" xmlns:mssgle="clr-namespace:Microsoft.SqlServer.Graph.LayoutEngine;assembly=Microsoft.SqlServer.Graph" xmlns:assembly="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:mssgm="clr-namespace:Microsoft.SqlServer.Graph.Model;assembly=Microsoft.SqlServer.Graph">
+        <NodeLayout
+          Size="269,42"
+          Id="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_GetTransactionTypeUpdates"
+          TopLeft="5.5,5.5" />
+        <NodeLayout
+          Size="256,42"
+          Id="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_TransactionType_Staging"
+          TopLeft="12,107.5" />
+        <EdgeLayout
+          Id="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging.Paths[OLE DB Source Output]"
+          TopLeft="140,47.5">
+          <EdgeLayout.Curve>
+            <mssgle:Curve
+              StartConnector="{assembly:Null}"
+              EndConnector="0,60"
+              Start="0,0"
+              End="0,52.5">
+              <mssgle:Curve.Segments>
+                <mssgle:SegmentCollection
+                  Capacity="5">
+                  <mssgle:LineSegment
+                    End="0,52.5" />
+                </mssgle:SegmentCollection>
+              </mssgle:Curve.Segments>
+            </mssgle:Curve>
+          </EdgeLayout.Curve>
+          <EdgeLayout.Labels>
+            <mssgm:EdgeLabel
+              BoundingBox="0,0,0,0"
+              RelativePosition="Any" />
+          </EdgeLayout.Labels>
+        </EdgeLayout>
+      </GraphLayout>
+    </LayoutInfo>
+  </TaskHost>
+  <PipelineComponentMetadata
+    design-time-name="Package\Load Transaction Type Dimension\Extract Updated Transaction Type Data to Staging\Integration_TransactionType_Staging">
+    <Properties>
+      <Property>
+        <Name>DataSourceViewID</Name>
+      </Property>
+      <Property>
+        <Name>TableInfoObjectType</Name>
+        <Value
+          type="q2:string">Table</Value>
+      </Property>
+    </Properties>
+  </PipelineComponentMetadata>
+</Objects>]]></DTS:DesignTimeProperties>
+</DTS:Executable>


### PR DESCRIPTION

# Pull Request: Fix Corrupted SSIS Package File

## Background
The SSIS package file located at `samples/databases/wide-world-importers/wwi-ssis/wwi-ssis/DailyETLMain.dtsx` was found to be corrupted. This corruption was preventing the package from executing correctly, leading to failures in the daily ETL processes.

## Changes Made
I have reviewed previous versions of the SSIS package file and identified a complete, uncorrupted version. Here are the steps I took:
1. **Reviewed Previous Versions**: Checked the commit history for the last known good version of the `DailyETLMain.dtsx` file.
2. **Restored and Completed the File**: Restored the file from the identified version and made necessary adjustments to ensure its integrity and completeness.

## Testing
- **Validation**: Ran the SSIS package in a test environment to ensure it executes without errors.
- **Verification**: Verified that all data transformations and load operations are performed correctly as expected.

## Impact
This fix will restore the functionality of the daily ETL processes, ensuring that data is correctly processed and loaded as per the designed workflow.

Please review the changes and let me know if there are any questions or further adjustments needed.

Thank you!
