### PR TITLE
Added log entry on catalog item migration warnings

### DIFF
--- a/samples/features/reporting-services/ssrs-migration-rss/ssrs_migration.rss
+++ b/samples/features/reporting-services/ssrs-migration-rss/ssrs_migration.rss
@@ -579,6 +579,7 @@ Function MigrateCatalogItem(srcItem As CatalogItem) As CatalogItem
 			For Each w As Warning In warnings
 				If w.Code <> "rsDataSourceReferenceNotPublished" And w.Code <> "rsDataSetReferenceNotPublished" Then	'This should be fine after re-linking
 					Console.WriteLine("Warning: " + w.Message)
+					LogErrorToFile("CATALOGITEM", "Warning: " + srcItem.Path, w.Message)
 				End If
 			Next
 			Console.ResetColor()


### PR DESCRIPTION
Added a call to LogErrorToFile so that warnings are also captured in the output log file.