### PR TITLE
Added rollback transaction before an exception is thrown

### DIFF
--- a/samples/applications/aspnet-session-state/aspstate_sql2016_with_retry.sql
+++ b/samples/applications/aspnet-session-state/aspstate_sql2016_with_retry.sql
@@ -204,6 +204,9 @@ BEGIN
             ELSE
             BEGIN
                 PRINT 'Suffered an error for which Retry is inappropriate.';
+				IF XACT_STATE() = -1
+                    ROLLBACK TRANSACTION;
+
                 THROW;
             END
         END CATCH
@@ -287,6 +290,9 @@ BEGIN
             ELSE
             BEGIN
                 PRINT 'Suffered an error for which Retry is inappropriate.';
+				IF XACT_STATE() = -1
+                    ROLLBACK TRANSACTION;
+
                 THROW;
             END
         END CATCH
@@ -348,6 +354,9 @@ BEGIN
             ELSE
             BEGIN
                 PRINT 'Suffered an error for which Retry is inappropriate.';
+				IF XACT_STATE() = -1
+                    ROLLBACK TRANSACTION;
+
                 THROW;
             END
         END CATCH
@@ -410,6 +419,9 @@ BEGIN
             ELSE
             BEGIN
                 PRINT 'Suffered an error for which Retry is inappropriate.';
+				IF XACT_STATE() = -1
+                    ROLLBACK TRANSACTION;
+
                 THROW;
             END
         END CATCH
@@ -471,6 +483,9 @@ BEGIN
             ELSE
             BEGIN
                 PRINT 'Suffered an error for which Retry is inappropriate.';
+				IF XACT_STATE() = -1
+                    ROLLBACK TRANSACTION;
+
                 THROW;
             END
         END CATCH
@@ -772,6 +787,9 @@ AS
             ELSE
             BEGIN
                 PRINT 'Suffered an error for which Retry is inappropriate.';
+				IF XACT_STATE() = -1
+                    ROLLBACK TRANSACTION;
+
                 THROW;
             END
         END CATCH
@@ -838,6 +856,9 @@ AS
             ELSE
             BEGIN
                 PRINT 'Suffered an error for which Retry is inappropriate.';
+				IF XACT_STATE() = -1
+                    ROLLBACK TRANSACTION;
+
                 THROW;
             END
         END CATCH
@@ -916,6 +937,9 @@ AS
             ELSE
             BEGIN
                 PRINT 'Suffered an error for which Retry is inappropriate.';
+				IF XACT_STATE() = -1
+                    ROLLBACK TRANSACTION;
+
                 THROW;
             END
         END CATCH
@@ -996,6 +1020,9 @@ AS
             ELSE
             BEGIN
                 PRINT 'Suffered an error for which Retry is inappropriate.';
+				IF XACT_STATE() = -1
+                    ROLLBACK TRANSACTION;
+
                 THROW;
             END
         END CATCH
@@ -1080,6 +1107,9 @@ AS
             ELSE
             BEGIN
                 PRINT 'Suffered an error for which Retry is inappropriate.';
+				IF XACT_STATE() = -1
+                    ROLLBACK TRANSACTION;
+
                 THROW;
             END
         END CATCH
@@ -1149,6 +1179,9 @@ AS
             ELSE
             BEGIN
                 PRINT 'Suffered an error for which Retry is inappropriate.';
+				IF XACT_STATE() = -1
+                    ROLLBACK TRANSACTION;
+
                 THROW;
             END
         END CATCH
@@ -1214,6 +1247,9 @@ AS
             ELSE
             BEGIN
                 PRINT 'Suffered an error for which Retry is inappropriate.';
+				IF XACT_STATE() = -1
+                    ROLLBACK TRANSACTION;
+
                 THROW;
             END
         END CATCH
@@ -1255,6 +1291,9 @@ DECLARE @retry INT = 10;
             ELSE
             BEGIN
                 PRINT 'Suffered an error for which Retry is inappropriate.';
+				IF XACT_STATE() = -1
+                    ROLLBACK TRANSACTION;
+
                 THROW;
             END
         END CATCH
@@ -1296,6 +1335,9 @@ DECLARE @retry INT = 10;
             ELSE
             BEGIN
                 PRINT 'Suffered an error for which Retry is inappropriate.';
+				IF XACT_STATE() = -1
+                    ROLLBACK TRANSACTION;
+
                 THROW;
             END
         END CATCH
@@ -1335,6 +1377,9 @@ DECLARE @retry INT = 10;
             ELSE
             BEGIN
                 PRINT 'Suffered an error for which Retry is inappropriate.';
+				IF XACT_STATE() = -1
+                    ROLLBACK TRANSACTION;
+
                 THROW;
             END
         END CATCH
@@ -1382,6 +1427,9 @@ DECLARE @retry INT = 10;
             ELSE
             BEGIN
                 PRINT 'Suffered an error for which Retry is inappropriate.';
+				IF XACT_STATE() = -1
+                    ROLLBACK TRANSACTION;
+
                 THROW;
             END
         END CATCH


### PR DESCRIPTION
When the 10 reties fail with an exception, and the THROW is called, the transaction remains opened. 