### PR TITLE
High Performance Plan check - change wording for clarity

### DIFF
--- a/samples/manage/sql-assessment-api/ruleset.json
+++ b/samples/manage/sql-assessment-api/ruleset.json
@@ -7909,7 +7909,7 @@
         "Configuration",
         "Performance"
       ],
-      "displayName": "Power plan is High Performance",
+      "displayName": "Power plan should be High Performance",
       "description": "In some cases you may experience degraded overall performance on a Windows Server 2008 R2 or later machine when running with the default (Balanced) power plan. The issue may occur irrespective of platform and may be exhibited on both native and virtual environments. The degraded performance may increase the average response time for some tasks and cause performance issues with CPU-intensive applications. Please note that you may not notice performance issues while performing simple operations. However, applications or scripts that intensively use resources (primarily processor and memory) may exhibit the problem. To work around the performance degradation issue, you can switch to the High Performance power plan.  However, this will disable dynamic performance scaling on the platform. Depending on the environment, if the platform is always under a heavy load, then this is a viable solution.",
       "message": "Switch server to High Performance power plan",
       "helpLink": "https://support.microsoft.com/help/2207548/slow-performance-on-windows-server-when-using-the-balanced-power-plan",
@@ -20629,3 +20629,4 @@
     ]
   }
 }
+


### PR DESCRIPTION
Just looking at the display name makes it seem like the server is already in high performance mode and that is the issues. The wording on the other checks includes should and I think this would make it clearer.

