### PR TITLE
Remove password in cleartext

### DIFF
--- a/samples/manage/azure-sql-db-managed-instance/attach-vpn-gateway/attachVPNGateway.ps1
+++ b/samples/manage/azure-sql-db-managed-instance/attach-vpn-gateway/attachVPNGateway.ps1
@@ -6,15 +6,10 @@ $environmentName = $parameters['environmentName']
 $resourceGroupName = $parameters['resourceGroupName']
 $virtualNetworkName = $parameters['virtualNetworkName']
 $certificateNamePrefix = $parameters['certificateNamePrefix']
-$clientCertificatePassword = $parameters['clientCertificatePassword'] #used only when certificates are created using openssl
 
 if ($environmentName -eq '' -or ($null -eq $environmentName)) {
     $environmentName = 'AzureCloud'
     Write-Host "Environment: AzureCloud." -ForegroundColor Green
-}
-
-if ($clientCertificatePassword -eq '' -or ($null -eq $clientCertificatePassword)) {
-    $clientCertificatePassword = 'S0m3Str0nGP@ssw0rd'
 }
 
 function VerifyPSVersion {
@@ -216,9 +211,7 @@ function CreateCerificateOpenSsl() {
     ipsec pki --pub --in "$($dn)Key.pem" --outform pem > "$($dn)PubKey.pem"
     ipsec pki --issue --in "$($dn)PubKey.pem" --cacert caCert.pem --cakey caKey.pem --dn "CN=$($dn)" --san $dn --flag clientAuth --outform pem > "$($dn)Cert.pem"
 
-    openssl pkcs12 -in "$($dn)Cert.pem" -inkey "$($dn)Key.pem" -certfile caCert.pem -export -out "$($dn).p12" -password "pass:$($clientCertificatePassword)"
-    #openssl pkcs12 -in "$($dn).p12" -password "pass:$($clientCertificatePassword)" -nocerts -out "$($dn)PrivateKey.pem" -nodes
-    #openssl pkcs12 -in "$($dn).p12" -password "pass:$($clientCertificatePassword)" -nokeys -out "$($dn)PublicCert.pem" -nodes
+    openssl pkcs12 -in "$($dn)Cert.pem" -inkey "$($dn)Key.pem" -certfile caCert.pem -export -out "$($dn).p12" --certpbe NONE -passout pass:
 
     $publicRootCertData = openssl x509 -in caCert.pem -outform pem
     $publicRootCertData = $publicRootCertData -replace "-----BEGIN CERTIFICATE-----", ""


### PR DESCRIPTION
The default password in cleartext trips up credentials scanners.

Removed the password since:
* The password is only required for OpenSSL and not with PowerShell tooling
* The script is used as part of a quickstart article
* The article using this script is not meant for production use