### PR TITLE
fixing the configuration of the extension

### DIFF
--- a/samples/manage/azure-arc-enabled-sql-server/modify-license-type/modify-arc-sql-license-type.ps1
+++ b/samples/manage/azure-arc-enabled-sql-server/modify-license-type/modify-arc-sql-license-type.ps1
@@ -432,8 +432,12 @@ foreach ($sub in $subscriptions) {
 
             if (-not $ReportOnly) {
                 If ($WriteSettings) {
-                    try { 
-                        $ext | Set-AzConnectedMachineExtension -Name $setID.Name -ResourceGroupName $setID.ResourceGroup -MachineName $setID.MachineName -NoWait -ErrorAction SilentlyContinue | Out-Null
+                    try {
+                        $settings = @{}
+                        foreach ($h in $ext.Setting.Keys) {
+                           $settings[$h]=$($ext.Setting[$h])
+                        }                        
+                        Set-AzConnectedMachineExtension -Name $setID.Name -ResourceGroupName $setID.ResourceGroup -MachineName $setID.MachineName -Setting $settings -NoWait -ErrorAction SilentlyContinue | Out-Null
                         Write-Output "Updated -- Resource group: [$($setID.ResourceGroup)], Connected machine: [$($setID.MachineName)]"
                     } catch {
                         write-Output "The request to modify the extension object failed with the following error:"


### PR DESCRIPTION
creating a hashtable for the settings to fix the az extension configuration for licensetype, no longer piping the ext object but using the Setting parameter.

The orginal code didn't work in my test environment, updating through the portal did work, by first creating a hashtable and passing it as a parameter I have been able to set the licensetype through the script as well.