### PR TITLE
Document Azure portal deployment for SQL license policies

### DIFF
--- a/samples/manage/azure-arc-enabled-sql-server/compliance/arc-sql-license-type-compliance/README.md
+++ b/samples/manage/azure-arc-enabled-sql-server/compliance/arc-sql-license-type-compliance/README.md
@@ -16,8 +16,8 @@ This repo deploys and remediates a custom Azure Policy that configures and enfor
 
 | Path | Use when | Files |
 |---|---|---|
-| **Command line / pipeline** | You want scope, assignment, role grant and remediation handled for you. | `policy/azurepolicy.json` + `scripts/deployment.ps1` + `scripts/start-remediation.ps1` |
 | **Azure Portal** | You want to create the definition by hand and assign it yourself. | `policy/azurepolicy.portal.json` |
+| **Command line / pipeline** | You want scope, assignment, role grant and remediation handled for you. | `policy/azurepolicy.json` + `scripts/deployment.ps1` + `scripts/start-remediation.ps1` |
 
 ## Choosing the license type by edition (compliance)
 
@@ -41,11 +41,29 @@ This repo deploys and remediates a custom Azure Policy that configures and enfor
 
 ## Prerequisites
 
-- PowerShell with Az modules installed (`Az.Resources`).
-- Logged in to Azure (`Connect-AzAccount`).
+- Access to the Azure portal or PowerShell with the `Az.Resources` module installed.
+- For PowerShell deployment, logged in to Azure (`Connect-AzAccount`).
 - Permissions to create policy definitions/assignments and remediation tasks at target scope.
 
 ## Deploy Policy
+
+### Option 1: Azure portal
+
+The **Policy rule** editor expects the policy definition's `properties` contents. Use the dedicated portal file because `policy/azurepolicy.json` includes the read-only `policyType` field and a top-level `version` field that the portal rejects. The portal file also supports `LicenseOnly` and uses it as the safe, non-attesting default.
+
+1. In the [Azure portal](https://portal.azure.com), search for **Policy**.
+2. Under **Authoring**, select **Definitions**, and then select **+ Policy definition**.
+3. Select the definition location, enter a name such as `Configure Arc-enabled SQL Server license type`, and select `Azure Arc` as the category.
+4. Open [`policy/azurepolicy.portal.json`](policy/azurepolicy.portal.json), copy the complete JSON document, paste it into the **Policy rule** editor, replacing the example content, and select **Save**.
+5. Open the new definition and select **Assign**. On the **Basics** tab, select the assignment scope.
+6. On the **Parameters** tab, leave **Effect** set to `DeployIfNotExists`, select the SQL Server extension platforms, select the **Target license type** according to the edition table above, and select the current license types eligible for replacement.
+7. On the **Remediation** tab, select **Create a Managed Identity**, choose an identity location, and select **Create a remediation task** if existing non-compliant extensions should be updated.
+8. On the **Review + create** tab, review the settings and select **Create**.
+9. Ensure the assignment's managed identity has the roles listed in [Managed Identity And Roles](#managed-identity-and-roles) at the assignment scope. The portal grants roles referenced by the policy definition when the assignment creator has sufficient permissions; assign any missing roles manually.
+
+Selecting `Paid` attests that you meet the licensing conditions described above. Selecting `PAYG` enables recurring billing consent as described in [Recurring Billing Consent (PAYG)](#recurring-billing-consent-payg).
+
+### Option 2: PowerShell
 
 Parameter reference:
 
@@ -136,15 +154,6 @@ This will:
 ```
 
 > **Note:** `deployment.ps1` automatically grants required roles to the policy assignment managed identity at assignment scope, preventing common `PolicyAuthorizationFailed` errors during DeployIfNotExists deployments.
-
-## Deploy via the Azure Portal (copy & paste)
-
-Prefer the portal? The **Policy definition → Policy rule** box expects the `properties` contents. The repo's `policy/azurepolicy.json` also carries a read-only `policyType` and a top-level `version` that the portal rejects, so `policy/azurepolicy.portal.json` has those removed (nothing else changed, plus `LicenseOnly` added to the allowed license types).
-
-1. **Policy → Definitions → + Policy definition.**
-2. Set **Definition location**, **Name** (e.g. *Configure Arc-enabled SQL Server license type*), and **Category** = `Azure Arc`.
-3. Open [`policy/azurepolicy.portal.json`](./policy/azurepolicy.portal.json), copy its entire contents, clear the **Policy rule** box and paste it in.
-4. **Save**, then **Assign**. On the *Parameters* tab choose your **Target license type** per the edition table above. Because the effect is `DeployIfNotExists`, the assignment needs a **system-assigned managed identity + location**; the portal grants the required roles. Create a **remediation task** to update existing instances.
 
 ## Start Remediation
 

--- a/samples/manage/azure-data-factory-ssis/sql-ssis-license-type-compliance/README.md
+++ b/samples/manage/azure-data-factory-ssis/sql-ssis-license-type-compliance/README.md
@@ -40,12 +40,26 @@ The deployment script will prompt for confirmation when targeting `BasePrice`. U
 
 ## Prerequisites
 
-- PowerShell with Az modules installed (`Az.Resources` for deployment; `Az.DataFactory` for remediation).
-- Logged in to Azure (`Connect-AzAccount`).
+- Access to the Azure portal or PowerShell with the `Az.Resources` module installed for deployment.
+- PowerShell with the `Az.DataFactory` module and an authenticated Azure context (`Connect-AzAccount`) for remediation.
 - Permissions to create policy definitions/assignments at target scope.
 - For remediation: Contributor on each Data Factory whose Integration Runtimes will be updated.
 
 ## Deploy Policy
+
+### Option 1: Azure portal
+
+1. In the [Azure portal](https://portal.azure.com), search for **Policy**.
+2. Under **Authoring**, select **Definitions**, and then select **+ Policy definition**.
+3. Select the definition location, and enter a name such as `Audit Azure Data Factory SSIS Integration Runtime license type` and a category.
+4. Open [`policy/azurepolicy.json`](policy/azurepolicy.json), copy the complete JSON document, paste it into the **Policy rule** editor, replacing the example content, and select **Save**.
+5. Open the new definition and select **Assign**. On the **Basics** tab, select the assignment scope.
+6. On the **Parameters** tab, leave **Effect** set to `AuditIfNotExists`, select the **Target license type**, and select the current license types eligible for replacement under **Current license types to overwrite**.
+7. On the **Review + create** tab, review the settings and select **Create**.
+
+This policy audits license type drift only, so the assignment does not require a managed identity. To update non-compliant SSIS Integration Runtimes, follow [Start Remediation](#start-remediation). Selecting `BasePrice` confirms that you meet the Azure Hybrid Benefit licensing conditions described above.
+
+### Option 2: PowerShell
 
 Parameter reference:
 

--- a/samples/manage/azure-sql-db-managed-instance/sql-mi-license-type-compliance/README.md
+++ b/samples/manage/azure-sql-db-managed-instance/sql-mi-license-type-compliance/README.md
@@ -29,11 +29,27 @@ The deployment script will prompt for confirmation when targeting `BasePrice` or
 
 ## Prerequisites
 
-- PowerShell with Az modules installed (`Az.Resources`).
-- Logged in to Azure (`Connect-AzAccount`).
+- Access to the Azure portal or PowerShell with the `Az.Resources` module installed.
+- For PowerShell deployment, logged in to Azure (`Connect-AzAccount`).
 - Permissions to create policy definitions/assignments and remediation tasks at target scope.
 
 ## Deploy Policy
+
+### Option 1: Azure portal
+
+1. In the [Azure portal](https://portal.azure.com), search for **Policy**.
+2. Under **Authoring**, select **Definitions**, and then select **+ Policy definition**.
+3. Select the definition location, and enter a name such as `Configure SQL Managed Instance license type` and a category.
+4. Open [`policy/azurepolicy.json`](policy/azurepolicy.json), copy the complete JSON document, paste it into the **Policy rule** editor, replacing the example content, and select **Save**.
+5. Open the new definition and select **Assign**. On the **Basics** tab, select the assignment scope.
+6. On the **Parameters** tab, leave **Effect** set to `DeployIfNotExists`, select the **Target license type**, and select the current license types eligible for replacement under **Current license types to overwrite**.
+7. On the **Remediation** tab, select **Create a Managed Identity**, choose an identity location, and select **Create a remediation task** if existing non-compliant managed instances should be updated.
+8. On the **Review + create** tab, review the settings and select **Create**.
+9. Ensure the assignment's managed identity has the roles listed in [Managed Identity And Roles](#managed-identity-and-roles) at the assignment scope. The portal grants roles referenced by the policy definition when the assignment creator has sufficient permissions; assign any missing roles manually.
+
+Selecting `BasePrice` or `HybridFailoverRights` confirms that you meet the corresponding licensing conditions described above.
+
+### Option 2: PowerShell
 
 Parameter reference:
 

--- a/samples/manage/azure-sql-db/sql-paas-license-type-compliance/README.md
+++ b/samples/manage/azure-sql-db/sql-paas-license-type-compliance/README.md
@@ -27,11 +27,27 @@ The deployment script will prompt for confirmation when targeting `BasePrice`. U
 
 ## Prerequisites
 
-- PowerShell with Az modules installed (`Az.Resources`).
-- Logged in to Azure (`Connect-AzAccount`).
+- Access to the Azure portal or PowerShell with the `Az.Resources` module installed.
+- For PowerShell deployment, logged in to Azure (`Connect-AzAccount`).
 - Permissions to create policy definitions/assignments and remediation tasks at target scope.
 
 ## Deploy Policy
+
+### Option 1: Azure portal
+
+1. In the [Azure portal](https://portal.azure.com), search for **Policy**.
+2. Under **Authoring**, select **Definitions**, and then select **+ Policy definition**.
+3. Select the definition location, and enter a name such as `Configure Azure SQL Database license type` and a category.
+4. Open [`policy/azurepolicy.json`](policy/azurepolicy.json), copy the complete JSON document, paste it into the **Policy rule** editor, replacing the example content, and select **Save**.
+5. Open the new definition and select **Assign**. On the **Basics** tab, select the assignment scope.
+6. On the **Parameters** tab, leave **Effect** set to `DeployIfNotExists` and select the **Target license type**: `LicenseIncluded` for Pay-as-you-go or `BasePrice` for Azure Hybrid Benefit.
+7. On the **Remediation** tab, select **Create a Managed Identity**, choose an identity location, and select **Create a remediation task** if existing non-compliant databases should be updated.
+8. On the **Review + create** tab, review the settings and select **Create**.
+9. Ensure the assignment's managed identity has the roles listed in [Managed Identity And Roles](#managed-identity-and-roles) at the assignment scope. The portal grants roles referenced by the policy definition when the assignment creator has sufficient permissions; assign any missing roles manually.
+
+Selecting `BasePrice` confirms that you meet the Azure Hybrid Benefit licensing conditions described above.
+
+### Option 2: PowerShell
 
 Parameter reference:
 

--- a/samples/manage/azure-sql-db/sql-paas-license-type-compliance/README.md
+++ b/samples/manage/azure-sql-db/sql-paas-license-type-compliance/README.md
@@ -58,6 +58,8 @@ Parameter reference:
 | `TargetLicenseType` | Yes | N/A | `LicenseIncluded`, `BasePrice` | Target license type to enforce. |
 | `SkipLicenseConfirmation` | No | `false` | Switch (`present`/`not present`) | Skip the interactive license confirmation prompt (for CI/CD pipelines). |
 
+> **Note:** Unlike SQL service types with three or more license states, SQL PaaS has only `LicenseIncluded` and `BasePrice`, so the policy always changes a non-matching database to the selected target and does not require `LicenseTypesToOverwrite`.
+
 Definition and assignment creation:
 
 1. Download the required files.

--- a/samples/manage/sql-vm/sql-iaas-license-type-compliance/README.md
+++ b/samples/manage/sql-vm/sql-iaas-license-type-compliance/README.md
@@ -27,11 +27,27 @@ The deployment script will prompt for confirmation when targeting `AHUB` or `DR`
 
 ## Prerequisites
 
-- PowerShell with Az modules installed (`Az.Resources`).
-- Logged in to Azure (`Connect-AzAccount`).
+- Access to the Azure portal or PowerShell with the `Az.Resources` module installed.
+- For PowerShell deployment, logged in to Azure (`Connect-AzAccount`).
 - Permissions to create policy definitions/assignments and remediation tasks at target scope.
 
 ## Deploy Policy
+
+### Option 1: Azure portal
+
+1. In the [Azure portal](https://portal.azure.com), search for **Policy**.
+2. Under **Authoring**, select **Definitions**, and then select **+ Policy definition**.
+3. Select the definition location, and enter a name such as `Configure SQL Server on Azure VM license type` and a category.
+4. Open [`policy/azurepolicy.json`](policy/azurepolicy.json), copy the complete JSON document, paste it into the **Policy rule** editor, replacing the example content, and select **Save**.
+5. Open the new definition and select **Assign**. On the **Basics** tab, select the assignment scope.
+6. On the **Parameters** tab, leave **Effect** set to `DeployIfNotExists`, select the **Target license type**, and select the current license types eligible for replacement under **Current license types to overwrite**.
+7. On the **Remediation** tab, select **Create a Managed Identity**, choose an identity location, and select **Create a remediation task** if existing non-compliant SQL virtual machines should be updated.
+8. On the **Review + create** tab, review the settings and select **Create**.
+9. Ensure the assignment's managed identity has the roles listed in [Managed Identity And Roles](#managed-identity-and-roles) at the assignment scope. The portal grants roles referenced by the policy definition when the assignment creator has sufficient permissions; assign any missing roles manually.
+
+Selecting `AHUB` or `DR` confirms that you meet the corresponding licensing conditions described above.
+
+### Option 2: PowerShell
 
 Parameter reference:
 


### PR DESCRIPTION
## Summary

Adds Azure portal deployment instructions to the SQL license type compliance samples introduced in #1490, including the existing Arc-enabled SQL Server compliance sample.

- Presents Azure portal deployment as the first option across five service READMEs
- Explains how to copy and paste the included policy JSON into a custom policy definition
- Uses the dedicated portal-compatible JSON for Arc-enabled SQL Server
- Documents service-specific assignment parameters, managed identity, RBAC, and remediation behavior
- Retains the existing PowerShell deployment instructions as the second option
- Clarifies that the SSIS policy audits through Azure Policy and still uses the companion PowerShell script for remediation

## Validation

- Parsed all policy JSON files successfully
- Verified relative policy links in each README
- Verified both deployment option headings occur once per README
- Ran `git diff --check`